### PR TITLE
Updates to ZIKDevice.name to support Swift access

### DIFF
--- a/Pod/Classes/ZIKDevice.h
+++ b/Pod/Classes/ZIKDevice.h
@@ -41,7 +41,7 @@
 /**
  The current human readable name of the `ZIKDevice` in the API. If not nil this should be used when displaying things to a user.
  */
-@property (nonatomic, retain, readonly) NSString *name;
+@property (nonatomic, retain, readonly, nullable) NSString *name;
 
 /**
  The type of device. Classifies a device based on what it physically is.

--- a/Pod/Classes/ZIKDevice.m
+++ b/Pod/Classes/ZIKDevice.m
@@ -37,7 +37,7 @@
 
 @property (nonatomic, retain, readwrite) NSString *uuid;
 @property (nonatomic, retain, readwrite) NSString *type;
-@property (nonatomic, retain, readwrite) NSString *name;
+@property (nonatomic, retain, readwrite, nullable) NSString *name;
 @property (nonatomic, retain, readwrite) NSString *state;
 @property (nonatomic, retain, readwrite) NSDictionary *properties;
 @property (nonatomic, retain, readwrite) NSArray *transitions;
@@ -81,7 +81,7 @@
         self.properties = [data objectForKey:@"properties"];
         self.type = self.properties[@"type"];
         self.uuid = self.properties[@"id"];
-        if (self.properties[@"name"] != nil) {
+        if (self.properties[@"name"] != nil && self.properties[@"name"] != [NSNull null]) {
             self.name = self.properties[@"name"];
         } else {
             self.name = nil;

--- a/ZettaKit.podspec
+++ b/ZettaKit.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
     'ZettaKit' => ['Pod/Assets/*.png']
   }
   s.dependency 'ReactiveCocoa', '2.4.7'
-  s.dependency 'SocketRocket', '0.3.1-beta2'
+  s.dependency 'SocketRocket', '0.4'
 end


### PR DESCRIPTION
Two changes to the 'name' property of ZIKDevice to improve Swift interoperability. First, this property is marked as nullable. This tells Swift code that it will contain either an NSString or nil. Second, the 'refresh' method was sometimes setting the device name to [NSNull null] instead of nil. This would occur when the dictionary building the device properties contained "null" for the name key. This causes runtime errors downstream in Swift since the expected type is NSString or nil. The name is now set to nil instead of [NSNull null] when "null' is detected.

Similar changes will likely be necessary for other properties.
