### PR TITLE
Troubleshooting

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - ReactiveCocoa/Core
   - SocketRocket (0.4)
   - Specta (1.0.5)
-  - ZettaKit (0.0.3):
+  - ZettaKit (0.0.4):
     - ReactiveCocoa (= 2.4.7)
     - SocketRocket (= 0.4)
 
@@ -29,6 +29,6 @@ SPEC CHECKSUMS:
   ReactiveCocoa: eb38dee0a0e698f73a9b25e5c1faea2bb4c79240
   SocketRocket: 01443933b7bc362621325f4607b80b4286a99707
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
-  ZettaKit: ac005b329f18743ec897d8ef251594fe23888115
+  ZettaKit: 01ad43280f961e490320fbb370f95d126775e9cb
 
-COCOAPODS: 0.38.2
+COCOAPODS: 0.39.0

--- a/Example/Pods/Headers/Private/ZettaKit/ZIKQueryResponse.h
+++ b/Example/Pods/Headers/Private/ZettaKit/ZIKQueryResponse.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/ZIKQueryResponse.h

--- a/Example/Pods/Headers/Public/ZettaKit/ZIKQueryResponse.h
+++ b/Example/Pods/Headers/Public/ZettaKit/ZIKQueryResponse.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/ZIKQueryResponse.h

--- a/Example/Pods/Local Podspecs/ZettaKit.podspec.json
+++ b/Example/Pods/Local Podspecs/ZettaKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ZettaKit",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "summary": "A Reactive Hypermedia Client for the Zetta HTTP API.",
   "description": "This library allows you to harness the power of Reactive Programming to interact with the Zetta HTTP API.",
   "homepage": "https://github.com/zettajs/ZettaKit",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/zettajs/ZettaKit.git",
-    "tag": "0.0.3"
+    "tag": "0.0.4"
   },
   "social_media_url": "https://twitter.com/zettajs",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -9,7 +9,7 @@ PODS:
     - ReactiveCocoa/Core
   - SocketRocket (0.4)
   - Specta (1.0.5)
-  - ZettaKit (0.0.3):
+  - ZettaKit (0.0.4):
     - ReactiveCocoa (= 2.4.7)
     - SocketRocket (= 0.4)
 
@@ -29,6 +29,6 @@ SPEC CHECKSUMS:
   ReactiveCocoa: eb38dee0a0e698f73a9b25e5c1faea2bb4c79240
   SocketRocket: 01443933b7bc362621325f4607b80b4286a99707
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
-  ZettaKit: ac005b329f18743ec897d8ef251594fe23888115
+  ZettaKit: 01ad43280f961e490320fbb370f95d126775e9cb
 
-COCOAPODS: 0.38.2
+COCOAPODS: 0.39.0

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,1264 +7,1206 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00728FA3CB18FD025773A2F91D100E49 /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 093078FB8BCBB56AF0438DA3CBB45122 /* RACEagerSequence.m */; };
-		038F5CFD3248085D90656C31ACB6E71F /* ZIKRoot.m in Sources */ = {isa = PBXBuildFile; fileRef = 33BE1AFB3E5E4655FB27567CB70D9911 /* ZIKRoot.m */; };
-		03FB8E16A98E72F50C904908CA4E06BC /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = 1647E4273B7E0BD7C404C2BF6756EF16 /* NSInvocation+RACTypeParsing.m */; };
-		04718F295655A0278A8C6E59E3B73400 /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = D4219300BCDF744DF30B8962281BFAB2 /* NSInvocation+RACTypeParsing.h */; };
-		056E7B1F79E16501396D1C9ADE0EAF7B /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BD16374160F79422053EFAAA3CC19C /* RACEagerSequence.h */; };
-		05AA13D8A34BDB9F6C0D24054A135AE4 /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = E573CCE8C9DB021C3550C9E79F48B117 /* RACTestScheduler.m */; };
-		05BFDFBAC5EF92C6ABC26480C528B057 /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C84D548FC73EA9BB169EE3019C1C0AF /* RACTupleSequence.h */; };
-		0621DE66B38960776582FB32C4D463B6 /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 201FB40811A25F91BC538292BFA9DFA3 /* RACEvent.h */; };
-		06AB0B63B184835D4451033CC22A7BBB /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = AFEA1BBC4BAF09959DE049C2AC6ECFF7 /* EXPMatchers+beginWith.h */; };
-		06BEB646C557CC34E8A16F291ACA810E /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A7FD71235C7DDFF3D97CB2A859A3AD7 /* RACSerialDisposable.h */; };
-		071F0030E3FCAD7E914954879A1816AE /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = BB54A9BD1067A9FBF329D95FB5C0E2F7 /* RACReplaySubject.m */; };
-		072318F89C37CFDEF19476152B3CAF24 /* UIControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E7418D91B25E6D9AA392FE90B771BF6 /* UIControl+RACSignalSupport.h */; };
-		0786AED0EF59E2200B76F30C1ECCDE44 /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B8E899FA45567F698CB1C4794484C9 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		079157EB995CC3507A04AD8D4D154F6E /* UIDatePicker+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D68B7CE019CBAA096DDE45EB2D6A056 /* UIDatePicker+RACSignalSupport.m */; };
-		08EA9841ABE58A0839BDDF539561B4CF /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = D2BA8B179D4FD25A3BCBAEEB16C676AD /* SPTCallSite.m */; };
-		08F92B755B99B0B3CA61D9E5CE1D5C6F /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 7643DDFA6BD4B41C819F0B038A54F9E8 /* SPTTestSuite.h */; };
-		0965013CD5E3AAC8B17A54B5C680C75F /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 40269D438003ADFFC4896C29734DED55 /* RACSignal+Operations.m */; };
-		09E7208829DB5BA8F397AB171B825C9F /* ZIKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EC8491A58BF2C5E2E76D9B29E3D1A3B /* ZIKSession.h */; };
-		0C0E4E87FC9BA5EC78F72E3B11C13A85 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = 081E3161312491061B4A24C184D46AC7 /* EXPMatchers+raise.h */; };
-		0C2C1835A2B120D3A15A51202AF1D9A9 /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 969330D3DA916F84CE8974997B87B044 /* NSIndexSet+RACSequenceAdditions.h */; };
-		0C495ED185087DE7F3FE71E3A382A72C /* ZIKStreamEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = DEED4633D5172B82272BC373AEC78624 /* ZIKStreamEntry.m */; };
-		0CFC315F73A199C37C77E906953A7A45 /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9850722D244E021478F2AFC9AFEA941A /* RACSubscriptionScheduler.m */; };
-		0D2862C43C2492E2167732E737B20236 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EA71D10164D8195F241085537964C92 /* NSValue+Expecta.h */; };
-		0D38231F8B9AAE9ADC6DA680FDA4F6DD /* ispdy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0191C029BD1ECA582E02CA24DE4A9D95 /* ispdy.m */; };
-		0D3FBB36339ACBAAB8DD646A43FB320C /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = BB96A5B5259F7CD5B16D87D43D0FD9A8 /* ExpectaObject.h */; };
-		0FC3A4AD97631071FDCDE43B2B5C6D26 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 965931BB62C9B2A504512CA6A6208307 /* RACDynamicSequence.h */; };
-		101F7083ECF2A6744C851F5F00F685EB /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = FAFFC9D358DDD39ECB0745FA2023B282 /* SPTSharedExampleGroups.h */; };
-		11B0BA4F75850B3BCAC8D653DF3D914B /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EB20819E758FF61FC1C313DF7D108D8 /* RACEXTKeyPathCoding.h */; };
-		12F70B413837D7E921278295813D5200 /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F945F3F5C9B2F367CF1D04074E9063 /* RACGroupedSignal.m */; };
-		12FE84EABD1399FBD048EE5364AE414B /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = 97CE60A6DDA33813333AF0B9EB93A194 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		130FFE26762F54717B4E4DBEA29F5A08 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = 27257204FF7BB2B319F60B68748779C8 /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		13582AC0E07964AF58B2B147568DE2A5 /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E0D605C9547170F5E5A1A850EA9E8EA /* NSDictionary+RACSequenceAdditions.m */; };
-		14477A8973DCABC6755CFF7379125835 /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EF7557877A35947FBF94568558DCFAFA /* RACMulticastConnection+Private.h */; };
-		14D59D21E9F244CCAEE1CDA608281768 /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A69E01AD132247A736B86F90C02B00 /* RACCompoundDisposable.m */; };
-		15A4432094FEF202DB5614B53544D617 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = A23DD93044E067DBC1FD549444602E5A /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		160EE3E96F342A127BBFB482F4A8179A /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E7656605139E2DF7947A1B93712E515 /* ReactiveCocoa.h */; };
-		1643F20F3E78395541907BA3E30A6177 /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 28197293FC0816184F9DD6F5B73F9004 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		16CDC87CE671B28A6D8F0890E4796840 /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F457EA3AA515EF706FAE471958452D6 /* RACTargetQueueScheduler.h */; };
-		190EBCD9EFD51C60314B23A4BDBF5ACF /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = B0DCDF6A21314BDEC414E3BEA2578D00 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		198D1819D0DE25B0CE556A683FDBB5D3 /* ZIKDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 65963049F3D276A28B72275D08D742DE /* ZIKDevice.m */; };
-		1A4A3D486667809C0DC731EBBE2D4A59 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F81A33D63E139320DC075C646EC4CD /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1A7DF66AB5C1BE27A1BDE4BB81FB075B /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31DC802B1F725960B0D821347C18D1E5 /* XCTest.framework */; };
-		1A93DB90E0361D24EACAAC918DFF2462 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FFB1C122FF3CFD89502B26937D763DA /* SPTCallSite.h */; };
-		1AB87CAF2E83E599E4C8E1DA1EC18951 /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FC39347B45D5339153AF336C38D9B50 /* EXPMatcherHelpers.h */; };
-		1B479B34C278460848338A2456BD2D59 /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 52FA142C78437F9A9E4EBB03F89D1B27 /* RACReturnSignal.m */; };
-		1BC608155C585E35636A79EA51D1A44F /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0C2EBA1F2CA0583C663B9A533E41EF /* RACDisposable.m */; };
-		1BFD166355BEF23FA5997643114A199E /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 2193B187592F9DE28CB3B599F4C99D86 /* SPTSharedExampleGroups.m */; };
-		1CDB291ABBA51C25F58AB49510C2AF76 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = F31D3A998B7205B4E0FFEE99616FE1AA /* EXPMatchers+beGreaterThan.h */; };
-		1CFEEBCCC6DBB7C9D53EBAD7D93F6847 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D775FFC9C2788090E0FB1EFFC080324 /* RACKVOProxy.h */; };
-		1D9DAD5C6CD32D5EC97E2F38B106744C /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 80456D3EBD0B983DC9A61E4B12B06A5A /* EXPMatcher.h */; };
-		1DA72E09AECD333C4918E1EEE794F1A2 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 03BAD800091C1652E4E87EFF3E9DC696 /* SpectaDSL.m */; };
-		1EA80C447F5DAFFD4E35731658A4460E /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 98201CFB2DAC97ABDEFAA86029E94E29 /* common.h */; };
-		1EBEA01019D07EBCE9E34E91AF48ABE4 /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = D5C37883AC62919434C8C3B761A06751 /* EXPFloatTuple.h */; };
-		202A870C640180ED0EF2959EC11BF11E /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E0ABD873ADA6AB516CA8CA48E477B1B /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		20366BD9C01C9115B898E2DCCD47634D /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B50757FB194775750692B1722CDA7EA /* RACSubscriptionScheduler.h */; };
-		20EE780E8EEFBB03591209C50AEBD085 /* ispdy.h in Headers */ = {isa = PBXBuildFile; fileRef = 55ED6F319D93F803132751875DF55547 /* ispdy.h */; };
-		215022D167A029BA1387F044D5BB8068 /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AC95017F44C94DFE1C03D89EA732B26 /* EXPMatchers+beInstanceOf.h */; };
-		21A9501DA541FA525DB626B32AAACC13 /* UIButton+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1481F317AA4D3FA9E8B4431E6E873 /* UIButton+RACCommandSupport.h */; };
-		23F6694D7C400F694742D29B52E5E025 /* UIImagePickerController+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 674EFBE953AD3B06A235EC0B5C0E8D50 /* UIImagePickerController+RACSignalSupport.h */; };
-		24775FEC384469772A3215FB4003DBB9 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D47E84989BB66D7CA4330E2F52A50E4 /* EXPMatchers+conformTo.h */; };
-		248333354DA5431D8854806A136DB102 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA0B1B8AECCD98A5DA0C29594AFEAF15 /* Security.framework */; };
-		251E41D55DB8988FE2497F2CDB70910C /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BB0AF273B85C0646D1A4B06202F6D10 /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		26B91942637CC1ECC50BF24DB3397FD4 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = ECFA49D9EC0EA2C510F999A4F4EA1802 /* EXPMatchers+beGreaterThanOrEqualTo.h */; };
-		2745F2B9E4AE8FD2D173177BF10C8C32 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A56E63A6C327D0B47BF98D555CDC5B1 /* Expecta-dummy.m */; };
-		28E5C463884ADD47DDC46200B4AE823D /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 7066A8216BB8CE14B85EEFD689CE5F8B /* RACSubject.h */; };
-		2A1483DE10527284B98CC5BF4ED1E73C /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = FC63BFBC105AD96C09128656B7BF41F8 /* NSObject+RACPropertySubscribing.m */; };
-		2BCEB05D07155176A17AD8F51136F674 /* SRWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 56971F82844624B96D2ACDA30390A280 /* SRWebSocket.m */; };
-		2C23DC1AEE0D3E5D30BFB8712DF33E8E /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = CF52CFD50AECD20F75BCAB84BF6898EB /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		2C9D47DF0AF13A3010462D40D3F989D7 /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FBFE427D22743C4C4FBEDF1DFFB8B1C /* NSOrderedSet+RACSequenceAdditions.m */; };
-		2D5E57A0D2EC1BCF9A82ECBCA0713C3D /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = E53AAAA4D493D789FCEA3BD930F01CCE /* RACPassthroughSubscriber.m */; };
-		2DC1FCB58E4E547A30E96286BFFEE7D8 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 82B63627E1B60335529B0A85337DFBA2 /* RACChannel.h */; };
-		2E4FE91FC73AB8BE1CC35135A569E81D /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD6B609F35559EA18FC4C6302ECF048 /* RACEmptySequence.h */; };
-		2EC3163F84F7FA998CD2E4D976DA8F6D /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = CF2DE738F1C28C1D76CCB6C87F9FD17B /* SPTCompiledExample.m */; };
-		2F182D3D3A130E372170287B97E60503 /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = DB58D49D15699D96337407A8A2C35AB4 /* RACEmptySignal.h */; };
-		2F4D345CFE47E8B2D68353120FDAC0E0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */; };
-		2FB3F8B188F8432E07F3902EDAA6D18A /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = BD0B172354987E049BCEAB7360A0AD1A /* NSSet+RACSequenceAdditions.h */; };
-		2FD5EAF1339873938E1A110A9F3C55EC /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D8B40E1B9008EA8D876D4E2FC933EA2 /* RACKVOTrampoline.h */; };
-		311CAC13FF8F181149C1187ED16D316F /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = FF58201FC056BB7FCDBCB159C14664FE /* NSArray+RACSequenceAdditions.m */; };
-		312564372D2BA844E4A8C73B467888BF /* UITextView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 751B822306AAB8E017F2D3241CF6AF3E /* UITextView+RACSignalSupport.m */; };
-		33A049056B8E6A425DA670B1F6652226 /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A9866A5BC46C75E35E36D2666D8F997 /* RACIndexSetSequence.h */; };
-		33A7BA0595B98BAA6DFA9DDC8433935B /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F4DF0C78D7F95F3A8AD05D71BF8AE24 /* RACBlockTrampoline.m */; };
-		3444E14B60E5CBA10BF566B28124E4C1 /* UISlider+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F615E19B20280D1880B90357C80B364 /* UISlider+RACSignalSupport.m */; };
-		35D6F88642BB4B314883E6E6076271F0 /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 02F56CE5B19A5F89FA9C32A454BF4C49 /* RACSubscriber.h */; };
-		3615E83769FE794AE868D5E56B628853 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F85A9E533C0C56DAE01D75712C9322B1 /* ExpectaSupport.h */; };
-		374D52A5032D68A37D316940BAB3C656 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FD5F6DB35C3BD89A4421E07F31516D /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		378E0082380C5CEC38BD4D041E9730B7 /* loop.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D0661C7B18B4DC7635DCE7AE6BF2890 /* loop.h */; };
-		386F8A3BCB064371F0BF2C343FD50C5C /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 33BB7F6EE2D7770EC191EE930AC170EF /* RACCompoundDisposableProvider.d */; };
-		38BEF6B499CFA1DAC9FB9219AD12BD50 /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = F32A618C5D89FA438702FDC36FBA0D75 /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		38CC62C595A2CE45AF600044F597C8EF /* UIStepper+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3F65A8A96CE404922B21DD9E38AAB9 /* UIStepper+RACSignalSupport.m */; };
-		390BD86E1B6B5E140017B0D5E6697086 /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BE4174116100A3787EC4636F12B6795 /* RACUnarySequence.h */; };
-		3A0F6CE2B333BA7C0250FD8C043FC5BD /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E116A852245F9AE7423AE3CDE7FBCB1E /* NSData+RACSupport.h */; };
-		3A6D61358792004C59225A190EDACB11 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C0A7E8190DDCE8CD41B61D10A7676B8 /* EXPMatchers+beIdenticalTo.h */; };
-		3D43B18EB1701601BB434174C2FF6540 /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D377B47B7C7F6DBF87DC8722DF2895 /* RACTuple.h */; };
-		3D64EEB7E6A1C368E9261F22138C244F /* ZIKUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F3A21108079A2E1E89C7AF36B8B1DFA /* ZIKUtil.m */; };
-		3DE1BF7BF8CBFC343C1B231EB589CEEC /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C7D4C0F72EA81B1B55A8B00FE947767 /* NSFileHandle+RACSupport.m */; };
-		3DEF75FBE8A8A90D8862CB967CB8EB27 /* SocketRocket-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB800A46024B1C2237C0FC9AC296F8F /* SocketRocket-dummy.m */; };
-		3EC719AACA92815955366285ECF9F25B /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 1155C4A11B46AB9BFC5B32CE3C89B294 /* RACUnit.m */; };
-		3EC753ED3A1B5343405344B5D5828EC8 /* ZIKQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D824F85C9A3F2F486A719978CC0B4E9 /* ZIKQuery.m */; };
-		3EFB7F7818D70DA2B9C871CBE124A3D3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */; };
-		3FE59D8FC674BA696E01DA072748271B /* ZIKPubSubBroker.m in Sources */ = {isa = PBXBuildFile; fileRef = E9AFFE6627D3125C9855BCBCA525AE0E /* ZIKPubSubBroker.m */; };
-		3FE80602458E3658ACDC02672228B79D /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FB60C485E0BB6B9535A63B57598619 /* EXPMatchers+equal.h */; };
-		40746E34173E60376213988F8146550A /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B6B7225FFF59C164E6280E85C6FC7EE2 /* NSIndexSet+RACSequenceAdditions.m */; };
-		429F18B8BE3A1C08767A2F60E79C4C50 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 866A8DF8152642E71A379E860431BF7C /* NSArray+RACSequenceAdditions.h */; };
-		4516E3DC4629B4277C38C9CB9AAF28CD /* ZIKMultiplexStreamEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 01FF14C73FA1CE2B9EDC4A39A0EEECA6 /* ZIKMultiplexStreamEntry.h */; };
-		451FD622A5348A27FEC27AFD155BF0AB /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 65D3988619FB1D4C6F906990B2633114 /* XCTest+Private.h */; };
-		467EC80D015528A50A394879FC005312 /* UIDatePicker+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 47B8C4F1228CB66BA3181891CBA0DB4E /* UIDatePicker+RACSignalSupport.h */; };
-		47B371BED3C685BCEAA549B8EA97F594 /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 0027C4B0CF621F607D7E2B8661A64AD3 /* EXPExpect.h */; };
-		4991020C842F25B083DF0EF25CB8A544 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BA333ED8DF8AC7A61AB648B5C010645 /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4A8A904C19CA595542F745713A304E44 /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 545C1E1CC57B35BBE7AE0F51A535A13E /* EXPMatchers+beSubclassOf.h */; };
-		4A9BB5B827C74024A8B0F0D7D4E62A84 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = C4A2E0FF371BAA7674764841CE9B6FC3 /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4B3175700FE9F2B219A822B7EDECA0B7 /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 15EBEFF8684157C7D981950827C477A4 /* RACKVOChannel.m */; };
-		4C0B5F76B7CAD31B6859C62C5708FD72 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AD3305FF4E3C4746C82AA701E2D9F8F /* SPTExcludeGlobalBeforeAfterEach.h */; };
-		4C6E8246699E4D745ABAA0DA9133AFB2 /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 4041595FE659F3590E2DD68D1B6DB398 /* RACSequence.m */; };
-		4CFB0DC81F9E4C7172DADAFF1AD02D09 /* Pods-ZettaKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A72AA5D46AE85EF9B309863E64165F2 /* Pods-ZettaKit-dummy.m */; };
-		4D2B985C52560B3CA9C1176A13E3796D /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FF5581A75B3140D834063B20311B2BC /* NSObject+RACLifting.h */; };
-		4D3DE0D21602EBC029BA1848F0C90848 /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = EE4AAC9129EC516135D799484C4228A3 /* NSUserDefaults+RACSupport.m */; };
-		4DE5DBBE43F6F260C18733927EB440E7 /* UIRefreshControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = EC5D8D51CFD27A8625EFFDB8914EA523 /* UIRefreshControl+RACCommandSupport.h */; };
-		4F589254367F6C974F110B3EEA264909 /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B96ECB90ACEB9BEEE6A96D1FDD9AD27 /* SpectaTypes.h */; };
-		4F7EB693C0124C67E778E5D7C55F5903 /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = AB1AAD99D6DC016BEB100A14C50706BF /* RACMulticastConnection.h */; };
-		4FD8A55CC93C7D950B444CC55D764781 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 98678187192DF65697D69FE4FE6A5559 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		508FCBD0D73CA33A6FEBF8D299DB2E62 /* UISegmentedControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9531E303E9D2A1C6DAAA81D34EBB14F4 /* UISegmentedControl+RACSignalSupport.h */; };
-		50904F7BB3386F63B0770F1D705E25E5 /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5613A39E0CC3C230CD3DFE338FBD9D05 /* RACSequence.h */; };
-		5156708912B3AC0EFA2469BE5298BC68 /* ZIKSpdyDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FBE7B5E036C81297BF24E9A54E824975 /* ZIKSpdyDelegate.m */; };
-		51C424CAB7AAF472D6FDE56195A6D140 /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = B27B1F5F1945C74B280C4507186F910D /* RACCommand.h */; };
-		51F5F030F97412AB1EF8CBCBD356F4DE /* UIActionSheet+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C61741E1194F8E72D51E3A65260818F5 /* UIActionSheet+RACSignalSupport.m */; };
-		52B6700CF02DB3B32EAD262C8FE514BD /* UITextField+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D2CB2CF0F32C1F316D49FB54DEB6AFCC /* UITextField+RACSignalSupport.h */; };
-		542C1CFC25DD237F0AF837A829485898 /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 343F1AD91DE594FB0E7441E12DC037A2 /* EXPMatchers+postNotification.h */; };
-		54F7826640E56F5232E10F4F64D08DA3 /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = E9B8F197F5B8F6E7ED1F441F5327C051 /* EXPMatchers.h */; };
-		554B6C009BE299FD6D2328C4C64E7DE4 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 5892393962A478CC5E04E99FE1A3757D /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		557B8ABB9717CD859C812F05069E237C /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E8BFF26288BA535373935740D7ADE254 /* RACKVOChannel.h */; };
-		55A1F246C81D4AF8DB47ECC98A20DA00 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = C993BB7AE60C5F33AB04CD700CAC0629 /* RACSignal.m */; };
-		55BDDC141C2412005DA247EC36417B82 /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 23F488A9B0F5CE26FC2321AF708C29B2 /* RACQueueScheduler+Subclass.h */; };
-		580EE17ADC44FCAB018F06C7C33368E5 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 2383BDAEE579F5C80A2BA3B682D038FE /* SPTExample.m */; };
-		581761AA776A29844071E0A36D53CDD0 /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = D1F3CFA42BBD89BCB20C2420D89C1A57 /* EXPMatchers+respondTo.h */; };
-		582CC301637EA96772EC7E3569D11A57 /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 30C010160F3AFB94CA4DEC12F2842BBC /* NSString+RACSupport.m */; };
-		58B62688542864D65412AE327DD6E579 /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = BF0DCFD973141FFA067FF687D364C77D /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		5B589842C88FB2F0FEA5E2E0415B9272 /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DD7F6BD61E294C23BA9A6AE080120867 /* NSSet+RACSequenceAdditions.m */; };
-		5BCB4A3ED72376C99C2AEA2D3F50141E /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = EAE2C53407FE51FF483D3BBCC97DB6DB /* RACArraySequence.h */; };
-		5BE14ADB6F0CD688931AD7E281D8846D /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = 5121C43167B486104EF1B5B4F91769AE /* EXPMatchers+match.h */; };
-		5C82ED4E0681E74CE3BBE639EA823A8B /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C2836BCC935BD8A46E618D13184C36 /* UITableViewHeaderFooterView+RACSignalSupport.m */; };
-		5DA28102AEE14A4622B8BB50F99F5A04 /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 9013288D8F73306EBE028303FBD87338 /* RACScheduler+Subclass.h */; };
-		5DAF61ACA0EF311EF313139EA8172995 /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A0F0406D12915CFF853CD338942C206F /* NSString+RACSequenceAdditions.m */; };
-		5DEEADC22BCFFCB48888EB2A40E5EFC4 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D450F935D5535460CD4F415DB8516D7 /* EXPMatchers+beLessThanOrEqualTo.h */; };
-		5E3A4C667A3AF193116CE223BE992AA7 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 539F8DA1A80C4B529B2BE97EF6A21E1C /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		5E90854F0265DFC2A143615E0E1DE173 /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CC78350520EF41E68B640BC8A5FEFFC /* RACCommand.m */; };
-		5FE1CB196B26EAE44C569759C6CD1E2C /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FB897D4EDDD20302EFE9CE101F3D7D4 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		62476B05C2D6B24F4F597D30E1E7B2DE /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = A69CE1A2EA59A2BD7B92147474A7F434 /* NSObject+RACSelectorSignal.h */; };
-		6274FD73F09EC2CF121F802F70140DFE /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D628F995FEC5E279B74E90E9733CA /* RACKVOTrampoline.m */; };
-		62ECCDB84FBC178EC784C6A0C8D25A40 /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 19AD852DA6297196F88BE42ECB5D5B77 /* NSURLConnection+RACSupport.m */; };
-		632F3FFF9F853CEB1AEBAE5221F1DC74 /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DA31B5E0ABBB6BFF37808E92019E42B6 /* NSEnumerator+RACSequenceAdditions.h */; };
-		64D3DD6BB9FE96B0A165C4C77496C5EB /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FE733D65B027C06DD030AD91BF135F8 /* RACStream+Private.h */; };
-		64E1D95C99BCFBC20551C5D703EB2B8D /* UICollectionReusableView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A4881E3CE72C3AADAE5448C921A461EB /* UICollectionReusableView+RACSignalSupport.m */; };
-		66487DE5A3045D4D2E2195D7B41D5E8B /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D3A94B2E9EC307ADA2AAB831105B61A /* NSDictionary+RACSequenceAdditions.h */; };
-		67204AB43957605094FDC910740FC892 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = DEE96CC83E6023D480F94C8408B016EC /* Specta.h */; };
-		6777AFC696F34BE679C862942C8C921B /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = FC5828955767805377F40939B33EDAC2 /* SPTExampleGroup.h */; };
-		6892D3C35CD328D4E4EA7059F91B6C81 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */; };
-		69712687D2092164B02CACA7DAB46280 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB36299CB4895BFB612150AED6E9436 /* UITableViewHeaderFooterView+RACSignalSupport.h */; };
-		6988F33B73C2924C8C765387399D41BC /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = CA4E32DFF53737F96B4EB48C07C099E1 /* SPTSpec.h */; };
-		6AE121A8DC66DEDB7D155D70E77DA38D /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 018381EE57997B3F939BCEA6CC4FAD1F /* RACmetamacros.h */; };
-		6B157BC77CF353C552F3902798138506 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = D96E13F7C73E07FEA48CD5198157A4B8 /* EXPDefines.h */; };
-		6C334EF65FA5C48AA3A5306A2497FC42 /* request.m in Sources */ = {isa = PBXBuildFile; fileRef = A53FA3E439D67AA7931E6A40CDB8CDE0 /* request.m */; };
-		6DE9508844E5026B224F0749878FCE47 /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 69B70C7D88057FD710BE665508EA82C2 /* RACEmptySequence.m */; };
-		6E21218B0ED0312F4DBCF360470608C6 /* UISlider+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 829D27E4966BA9A9DFC007200AEF9351 /* UISlider+RACSignalSupport.h */; };
-		6F5353645F7884E1411DDFA99554990F /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FDE9712AE0D061DE230EDF8D1E75D096 /* NSString+RACSequenceAdditions.h */; };
-		6FAE46DD86F070280779C9A69510D53F /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = A44505ADC9A93CAC7F0AD3E2AE384BAA /* NSObject+RACLifting.m */; };
-		72134CEB6FD22455BB445072C8AF8A2C /* ZIKServer.h in Headers */ = {isa = PBXBuildFile; fileRef = BDCB5CEF1814EC7E43CB748B6C1D2A2E /* ZIKServer.h */; };
-		730AE7622E26C1F20305098A1AEE7D19 /* ZIKStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BC55603216527453AE4FB44CC0B3B1A /* ZIKStream.h */; };
-		7341FB6CD51299C098677C59F9190A96 /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = A6E08205EDA9CBD3268E27962E943651 /* RACReplaySubject.h */; };
-		73542480627EFC2762EC1D3042335BFF /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = EE6CA8DDEA2D1749EF81694FA0D05C7E /* RACImmediateScheduler.m */; };
-		73E42B7BB6A86B2ABE123CC9FA207322 /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BCFE802A9187865C3913B48062E692 /* RACSubscriptingAssignmentTrampoline.h */; };
-		74C145F9F54F16EC8A2C7B00F5383DCF /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CFB9F140491EF5233B5B6DF1638D571 /* RACScopedDisposable.h */; };
-		7543FC0118AA7C066C74CAF7915FDAE2 /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DBE662463B3987D25CEED40D39FB676 /* RACSignalSequence.h */; };
-		75E013B9C4722F9094A22932A38A6D47 /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = 23D73C10A5A05E97D81B467C67A1310E /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		777CA6F4A9FBE830D235E6408A55F8EC /* UIStepper+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = EA9D007B04968D2533787298BE4632D5 /* UIStepper+RACSignalSupport.h */; };
-		77C1632196F30995F9AECABE077A90D2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */; };
-		798C6CEDF3BE134A2198A9874D1810E6 /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = 79370742F5DFE2A0E4C8276DD740EE61 /* NSObject+RACDeallocating.m */; };
-		79DC28F597FA0AF120A8B9D2634E84C8 /* framer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FF6936CE62992A4B9996A0E32768C1E /* framer.m */; };
-		7B011BCB282C6AD41F83458851CB454B /* ZIKUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = FF29AE10C019BD4873E0DC281AFF75A3 /* ZIKUtil.h */; };
-		7B624D69FD81E49B03BF95F0A49BD598 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 766AFBEC903C05FD57DFFD1B16BB5437 /* SPTExampleGroup.m */; };
-		7B77A0741056810E7AFD0404A1102E42 /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E34BDF21903B14C620935FC77698BF4C /* NSNotificationCenter+RACSupport.h */; };
-		7BFB95A70E54DBED0CBC911D9BCE7AA7 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA002324460D09BB5D72A80C49FE986 /* RACUnit.h */; };
-		7C85F632BF7E4E94D331B57D2841BCD1 /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = EC79E67C6584F76B74F385ADE15704A1 /* NSObject+Expecta.h */; };
-		7CDBF7E64AEDADCEE3D494E7B9085B94 /* ZIKSpdyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 78344F6C65F3DCF875A9EC8F70750528 /* ZIKSpdyDelegate.h */; };
-		7E9CED19AB172CCEA0E3CD7B909C62B5 /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = FB7076DABFA78042AB6E9389ADAA9398 /* RACStream.m */; };
-		7FE619BD3F4B1CD8A163A8BCEE1ACB08 /* UIGestureRecognizer+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = BFCA99B5C0AA2B98264CB07A3110BB66 /* UIGestureRecognizer+RACSignalSupport.h */; };
-		804788542E20265849CFE1E5B13197E3 /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2E0A8616542DF80071FFE254B3EB9A /* RACValueTransformer.h */; };
-		80AC87407A3E1FBE91CC221DCA9D8333 /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = BBD98081124D8A75CB4059FBC90AD6E3 /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		80F3ACAB998825EAE83E15190BC212A7 /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C8BF96FCAEF5B295961CC7377CDFDE14 /* Specta-dummy.m */; };
-		8194F33B1F05DCF6FE35282BB5FDDF85 /* UIButton+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A36CEF3E5D04D7B9EDA2B6C0ED5197 /* UIButton+RACCommandSupport.m */; };
-		82AA8237410AA975A398827ACAFEA6E0 /* LICENSE in Sources */ = {isa = PBXBuildFile; fileRef = E97AD6B9417405A4D6A9DF2773C99A33 /* LICENSE */; };
-		8341D6CAD7AE2B33590C8147513A6DE9 /* compressor.m in Sources */ = {isa = PBXBuildFile; fileRef = E46A97013558386BBB9749C6A051D894 /* compressor.m */; };
-		837370EF86F1DBBDC12231AB837BC0B6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */; };
-		8477700FA844329D5CB2EAFD186A9B36 /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = C18E3C2B5B05581989FBAEE89CEFFEEF /* RACChannel.m */; };
-		853F7B81E1945B0215C76BAA92BB4A55 /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 47A8BFEE5942CA0FD0E5E0BA5F323B30 /* RACQueueScheduler.h */; };
-		85735B9DBB1A98626A45E6D72E0B9B75 /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F56B09E67C8713A35F5BF7D9A81009BF /* RACGroupedSignal.h */; };
-		86F297AFDEE13C7A2B7E195E980B678D /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AEF653A1037E7A89C1C1CC2732C30A8 /* RACDisposable.h */; };
-		87407A7D9DFF81394E6003FC95FCDD0B /* UIImagePickerController+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C12C84BECEA822C8E998EDCA34F85C /* UIImagePickerController+RACSignalSupport.m */; };
-		8777929E50F4214719FA63A12188D8A0 /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AC3C4882E27A01D5721D5AB3AE3A4A5 /* RACTargetQueueScheduler.m */; };
-		879DDE3C5F6939680AEF9132529637EF /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 115C199FC5D2399E662C60DECE8BECDD /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		87F5AF0D77C560173C3254A5C76C1156 /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3F63CEE7D957475C690D21744C92EF /* RACImmediateScheduler.h */; };
-		887B38FF249355B3B743798C9EC5615E /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = D3078A0545D4B0A369AED052E0A1C51F /* EXPMatchers+haveCountOf.h */; };
-		8884ABF795D44AD705FD883B37F92D62 /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = F36D7D16B9DF57C4E4B5185F4FCDE9F5 /* RACUnarySequence.m */; };
-		8AE736B3465BDE90D4FA6424FBCDFF50 /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = EA15C56084EFF2F27C63DA16BCEDF025 /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8BB6AD6178E6CCBA6DED3C434F7828AF /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 6287254A6C5A7A83041A0DA692E17E9B /* RACDynamicSignal.m */; };
-		8C16389598BFB5133687A00192FFD3E9 /* UICollectionReusableView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = CD275CF459A5ADA1EE193B6FACF58D60 /* UICollectionReusableView+RACSignalSupport.h */; };
-		8C263912AFCDE7BFB6295AEA8DDEC8CD /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A3BB8E983EB259F68EEF97FA0B7A8BF9 /* EXPUnsupportedObject.h */; };
-		8D7305C6505DF1A47CF4AC9636C9292F /* RACEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 202BC15722571669D200E8ADA64B2BEB /* RACEXTRuntimeExtensions.m */; };
-		8DF78B4AFAB3C125B26FDBCAE519B856 /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E09C91E369C4586C4831F618F831AF /* RACScopedDisposable.m */; };
-		8EA940BC2B89B4214909C237323748F8 /* UIControl+RACSignalSupportPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 929D00BB58123B006BFD678778A36407 /* UIControl+RACSignalSupportPrivate.m */; };
-		8FDE97508FF26BD3BBE204A497CE9C7E /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 52A23864040D30E50974CD5F0DD11AE5 /* RACScheduler+Private.h */; };
-		908C06745098D7AF7860282B9365C723 /* UISwitch+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D6B5E91193C842C95227E963B247EE3 /* UISwitch+RACSignalSupport.h */; };
-		90D140E4C4AB174D1FF089507D1D252F /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 5553608D3E681310854569BC39EA7567 /* XCTestCase+Specta.h */; };
-		90EF778245546FE3E72C92591ADE6275 /* UITextField+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D04F30589CA7E633520E1BF71902834B /* UITextField+RACSignalSupport.m */; };
-		91F30950A838A3C253E64551B29AF177 /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4A7FE62604FBEB893337F882F60EAD /* EXPMatchers+endWith.h */; };
-		92016529A9885C6BF3724468319F058E /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 41612113711B99B4D5EDF19455EA0580 /* NSObject+RACKVOWrapper.m */; };
-		9358AD65D0CD80ADAC6A37B8B7A3EEC4 /* ZettaKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C2A2948C50676C32CDBDBD3657A0D7EA /* ZettaKit-dummy.m */; };
-		94778C82680B97105B2D931FBF7E59F4 /* UIRefreshControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 764CC59FC8A9C5A716530F6C0633CA36 /* UIRefreshControl+RACCommandSupport.m */; };
-		9499F9FDEA003A2FB4A33670ADA650AF /* RACBacktrace.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A8EE7EC34BC6EE2E2E9989ED0139B9F /* RACBacktrace.h */; };
-		956F617F4A4989F53049F8BD309BFF90 /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = AFC35025FCE2CC972744BBF5FEF23360 /* RACSubscriber.m */; };
-		95BD576E322CC3450069B6445241B44A /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = D0BBBA920D9AB650E46AE31391311239 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		95D0DC080D24C070CE6512B2BC51A00E /* ZIKMultiplexStreamEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 902F5FD98CA6F8F6FF159687D5ECD159 /* ZIKMultiplexStreamEntry.m */; };
-		95DA33E52A0C0194E013EDEEAE6E2D06 /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7469EBB0EE6B9C6EC1CBBFA94B1554 /* NSObject+RACKVOWrapper.h */; };
-		96254770A5E1A6986543D44A42321170 /* parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D1BE39A7BE68902A951E7C1A15B7DC /* parser.h */; };
-		9631D62FE3494E1814BE6CAA64215516 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = AECDA5692B621682F2E7AAB714AC3DE7 /* EXPMatchers+beKindOf.h */; };
-		977F5E4E2DB98B7CA2CF08B882048430 /* ZIKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA55823DB3770639916D4F68BCA4028 /* ZIKSession.m */; };
-		97AC67AEF9570BE0E11F5A130E3DFA10 /* ZIKStreamEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = BBABF04D8BD625E55C45D08668540043 /* ZIKStreamEntry.h */; };
-		98015E4C2BFF8B596C6E6948F1707ED0 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = 91D8A1EC4259D460C1846F2DB88F2C84 /* NSObject+RACPropertySubscribing.h */; };
-		985FB534AAFB396E4B51428F25C3EDD8 /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 69DD4A8A195C14D7B67FC1103624E4B6 /* EXPMatchers+beSupersetOf.h */; };
-		98D16CC61273DF365D7D1FDC220A61CF /* scheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D29DFB589146C16E787DA8D99C67457B /* scheduler.m */; };
-		99322F6F076ED2C4E79A56C347C1E51C /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 53F26C05150855A98E88A602F4DB3725 /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		996AB105A2F5A9D339F67BF98089C63C /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = A24DF0C64AACE3F56BA0F5EF133BB532 /* README.md */; };
-		9A9E34137CF5EE0F4AD2E333CC2302A2 /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 6484E48827DACC26C101BB153E4DA868 /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		9AB4BE742E7937452B88BA5BBF914007 /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = E74AC17C2CF5C0313BB096210B7971E6 /* RACBehaviorSubject.m */; };
-		9ACFAF6CDBBFC38FFCD4A279B6329491 /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E781F612A4CA483CECB9598AFF7256B /* EXPMatchers+beTruthy.h */; };
-		9B9FF575A57BC5A326E01324BC430308 /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 15FA16F0D5C03728F01CDA5EADC5FCA6 /* NSData+RACSupport.m */; };
-		9BDD9B5C0123A65FD597FF85712762B5 /* UIControl+RACSignalSupportPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 86B87C7E3D18D5348EB52D09B39E0BDF /* UIControl+RACSignalSupportPrivate.h */; };
-		9CF364D8054F811CC83935BFE31587C7 /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B168AC1BB12F4DE7CB999A34B9EE6FAB /* UIBarButtonItem+RACCommandSupport.m */; };
-		9DEA3D740E24D640765F756BCA825478 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 93029730447E84BE07FEF552E631522D /* SPTCompiledExample.h */; };
-		9EC9186F63D8BA3D2D993F011E2257DE /* SRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 29DF0EB3518882D15FABD9EE8F48A47E /* SRWebSocket.h */; };
-		A000D37CEECF04A0566AC0FC4BC005A4 /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 93136A340786946A1744EEF21ADB3813 /* RACObjCRuntime.h */; };
-		A5651594EC1B0111A8433B4DAE5958A2 /* ZIKPubSubBroker.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B318510EF225CFC16F065802B4375B /* ZIKPubSubBroker.h */; };
-		A5D7747C1CC85D8D024FCCDD8B3098DC /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EF167D699D7776368ACCC311AA44E95 /* RACScheduler.m */; };
-		A6B903969894C2D9F884683ACC32F8EA /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = C8304142657F82BDB22B7ACDE39B7705 /* SPTTestSuite.m */; };
-		A745CCC4FBB3CE81A397FC6E30079261 /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 08AFC5D5C2718231F4C3ED02D2123B7D /* NSUserDefaults+RACSupport.h */; };
-		A90D195405682FE62B855C1AE68E80CC /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F4158EBD4E8E18F2AF4568A2617E694 /* SPTGlobalBeforeAfterEach.h */; };
-		A98896839A96771C7A49F120AD8A7A96 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31DC802B1F725960B0D821347C18D1E5 /* XCTest.framework */; };
-		A9BFD880013117F7CF66D6F32DC2CAD0 /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DBE53E0D0A9D6B0BA879F7EAD2C7310 /* RACEvent.m */; };
-		AB0BC7F16D3C5455CE5F431543F0FD84 /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = E9C694BE73E4F96617FAAF17E40ADE3C /* RACMulticastConnection.m */; };
-		ACB4F3E7711FE4B2E19600BB36ABB1AD /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = CB51EBDAB2BA5E4AC46C870684FD6181 /* RACPassthroughSubscriber.h */; };
-		ACC38020DDB485B1BB0C4CC358F78B10 /* RACEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CD337E30EEDD66408D742FA6EE2BDC5 /* RACEXTScope.h */; };
-		AD2B2C387666F13D2DA4E834377EC4BB /* UITextView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 092669775C6D16219510B67D37706726 /* UITextView+RACSignalSupport.h */; };
-		ADFA5655A3BE3F3A29DF18F3D204CB41 /* ZIKRoot.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EBA97F8EE77602656B8F3244AEB15A8 /* ZIKRoot.h */; };
-		B1632E75D7D3D3B2A8F4FDD50EF5C915 /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 74EB00DD5C542B047701064CA3AC8BDE /* NSObject+RACDescription.h */; };
-		B23B2316C687E70EB5429EB11C485022 /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = E404DFDD176C035583EE3E27C674F4C2 /* SpectaUtility.h */; };
-		B4292F4254BE0AEC3FB70C6BA2512188 /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = A15C42C144EA0025F7F35F283F4E0E8F /* RACStringSequence.h */; };
-		B45FFA09D7FDDEDF72F6BA657F27FCB7 /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A1EB323DA97E986FED958F224E08993 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B50322B046EBAB1F11A0D44781D8493D /* ZIKLink.m in Sources */ = {isa = PBXBuildFile; fileRef = A3744DA45A5C7438CFFD2FE1721C0916 /* ZIKLink.m */; };
-		B693EF8A744DD2FB2FB6473C34CDADE7 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = B9B5E84290F765C88A7EE0A2AE61516B /* RACTestScheduler.h */; };
-		B8B20783EF02164BE8C059FB21919DF6 /* UIControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 4261CD967FB77A20DA53A438C37DF7C1 /* UIControl+RACSignalSupport.m */; };
-		B8B54EA62B1D90C028FE2B431844098E /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F56CD047BEB7C6A003B63CA4718AE41 /* NSObject+RACSelectorSignal.m */; };
-		B8F7FBBA1AE11BF755D655D3EF7E763F /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = C0BAA20725F0829A4BDF98B119FB4D53 /* RACErrorSignal.h */; };
-		BAA6443ECC3509B5681215B29ABF4C7B /* RACBacktrace.m in Sources */ = {isa = PBXBuildFile; fileRef = 546BB867D098E9B9C3019D8541BE2EEC /* RACBacktrace.m */; };
-		BB140B384F40D654C2E01C5D8D408EE5 /* UITableViewCell+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E48C2BFC97916C067AFA88FCDBA67769 /* UITableViewCell+RACSignalSupport.h */; };
-		BBFC3693A83D237CB589026016521EF6 /* UIAlertView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 04D46DBAD30879A86FBEE7ED8EFC736B /* UIAlertView+RACSignalSupport.m */; };
-		BC3687F00A97092E75F467D710E21C22 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 15D02E4033F4D6EF61F7E71C4C5A6047 /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BC5CD40866692F6DD88AAEC6DE99B51B /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 67CC2BE33D4A7B41784DB071217D83C3 /* EXPMatchers+raiseWithReason.h */; };
-		BCA773A11AA4FCA536957D5BBB0CBCA6 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FC2080F4068B93C0E233FD81F6BB5DC /* XCTestCase+Specta.m */; };
-		BE00E57A48DA27A2D02009D1582CD9C2 /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = A25F6660B65F52A1F2C80A9BC2A691AB /* RACArraySequence.m */; };
-		BFCE6C8A7FF824E243415A76EE5687BF /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = A4FE3029CCF36904FE8E4599B033DD1A /* RACQueueScheduler.m */; };
-		C1142B3887048C11E3AE76291711001C /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = 95B6CF2D186FAA0D592B5DE28D92C00B /* NSObject+RACDeallocating.h */; };
-		C127E0D2CDAFE97C0841AF292B39C97E /* ZIKDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = EBB6A2AC8482158DD065C6E623FB57E3 /* ZIKDevice.h */; };
-		C14ED0320B0C3A1722B881C111491843 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 722BA1E5F28F49563D04F5A1DF32CA42 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C2C4D5979CE32C0648256B97BE154D59 /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F77ADCE2A6CB9E500BBC52CE5F68F2C /* NSOrderedSet+RACSequenceAdditions.h */; };
-		C372414F808CB17ACCCBD00F2601CF1B /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 775477D4D81CB05B257641F615064B46 /* RACBehaviorSubject.h */; };
-		C3E0BA74990CE99E1804ADBA446445D9 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CFCB2F8A59C2DA5ADF2F682B1BEAA09 /* CFNetwork.framework */; };
-		C405F06E7766EAA8C4B3BE163EF0F2EC /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = A1749AC4C11FA3F64A7D18023E0638F4 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C4DAE253D99AB1CE0CA14740EE484164 /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 1500FDD1767362848287A77BAB4ACD64 /* RACStringSequence.m */; };
-		C515672C64B8CFDD8DA630E3B8236493 /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BEFD09469425B8A59DD281F2D23A3F2 /* RACDelegateProxy.m */; };
-		C54C1EDFADC8FBB1EA21B2FE359EBA44 /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C289C470169EC72DD86E947E58F182B9 /* Pods-Tests-dummy.m */; };
-		C5CAC6A2E7158B16713AB4BEBE67A00A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */; };
-		C61ADEC820AE7DA9AC3E859292B4FC0C /* UIGestureRecognizer+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 21003E153499263B2F932EDD9F77F1DF /* UIGestureRecognizer+RACSignalSupport.m */; };
-		C74CC5619A1ED5E8A3553D43B5C97028 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 64969607553A419F55D68772C21096C9 /* RACKVOProxy.m */; };
-		C8D7A9D4DA4214C519D7D35DEA516D01 /* ReactiveCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A7822E15A991503A82F5FEE6E582F0BC /* ReactiveCocoa-dummy.m */; };
-		C97274A2EBD04024761E9F4526C81AC6 /* ZIKLogStreamEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 82E526B3AAC4E22005C261AC77230110 /* ZIKLogStreamEntry.h */; };
-		CA3D140B1572DA580B270999D5B85007 /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 01AE5DBAA417EF1DD630392B857C33E1 /* RACSignalSequence.m */; };
-		CA8B711843F3D0DE16A764C26FF87AD6 /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CF5963F7A99D286F3FCA0DB7135C58 /* NSObject+RACDescription.m */; };
-		CAAE9BED08C1AE6605F9BA007DBC7D55 /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 47E31E9FFF0ACC7D29F7C49292E390CA /* EXPDoubleTuple.h */; };
-		CB17BB41BEC9C9663886E3479F2CF651 /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = 211FAB023F6DB10974ED4122E5357AF0 /* EXPMatchers+beFalsy.h */; };
-		CCC0870C6FDB9DBF069DEAAD62A17100 /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DB33A1AB7C51F3D80DB728C8F87D7DF /* NSEnumerator+RACSequenceAdditions.m */; };
-		CD31B164A246331196D92C70F2163A19 /* ZIKTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 60638554325FEAC8776DDAE4CCDE5633 /* ZIKTransition.h */; };
-		CDA765AB7544DDABA28C3B207917DF35 /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7F69B7E5EF12903A4332C83A36E21A /* RACDynamicSignal.h */; };
-		CE3710E77A2905E64DA3B708D0429AB5 /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = B40962D8C0896819D87F62AB061E8D72 /* RACCompoundDisposable.h */; };
-		CE4191522CD109C5EF82F321FAC498E4 /* parser.m in Sources */ = {isa = PBXBuildFile; fileRef = 2058EBEE764BEEA8354D1A4D32C972F1 /* parser.m */; };
-		CF27535860BB51E65495A9F9831B1D12 /* UISegmentedControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FE3B185463A321496134062A3DEED8 /* UISegmentedControl+RACSignalSupport.m */; };
-		CFAFB58A6A385246F39AAEBB3D0EF67B /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = DC02B51E08E685F6D84ED2E35F49729A /* NSString+RACSupport.h */; };
-		D04AC40E5BDBC583E2F24D07229DC1C6 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = C1F4289E67A4C35B37FD33E2B7BE7651 /* EXPMatchers+beLessThan.h */; };
-		D1CF2CDDB9ABDC0D04CAC59237496563 /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0014D3C1086C02FCA5753BE1B850AC72 /* NSURLConnection+RACSupport.h */; };
-		D35A0ED585D2B12CB6E6805C8F7ED9CB /* ZIKQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = C525C73AA385D16886B341BFA97FE274 /* ZIKQuery.h */; };
-		D3C4E5383F87710DCE68B40FAE69D191 /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B570849141B86EF4DBE208657D201336 /* NSFileHandle+RACSupport.h */; };
-		D4851D2DB0ABEC3DD339126DE788A2BE /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D6D611AACFA11DA2CB730200A1E0F329 /* RACBlockTrampoline.h */; };
-		D5AC23B010FC6F0BF9782B7BC26DCE0F /* ZIKStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 85E1916DC30855C0CF4C5FD890F34811 /* ZIKStream.m */; };
-		D6512D8345593243DE6E96B75EB00991 /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = FA24CA8CDD807FAB5C75C3CBCD471603 /* RACEmptySignal.m */; };
-		D75CE78CE7CC7F2942CE8D9A706E3777 /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 942815D7546898BCF8AF15C5DC9625BE /* RACSignal+Operations.h */; };
-		D7D9C177BAA333422295E078C9EA5F17 /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = A4C247E3A3979D1AE480DCC03A895A20 /* EXPMatchers+contain.h */; };
-		D7EB04C3267DA586AE90CFE7B0D45C14 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 147E3E9145BBADBD45B55AAA3E000BC0 /* SPTExample.h */; };
-		D8395F6D361B1793C5686AA6D99C1C52 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 07514E922FF2FD77D088C58D3EAF7622 /* SPTSpec.m */; };
-		D92C639CB9FA54D23CE6530221C33E4B /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D1637BFAABEF75B5A08A03A500EC5C6 /* RACErrorSignal.m */; };
-		D978BBA9B0BA6153B3FA7FE4D24006B1 /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = C94E4E78014DCF2A5ED99F78C3BD69DC /* RACStream.h */; };
-		D9E725B077E4EE39D1F2699052F26AD1 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = A99E8C74ECF9EC410DC49AF4467097BD /* EXPMatchers+beNil.h */; };
-		DA2CA26AC8F0CE550F56D47E222811B8 /* framer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6689654F63605798C353AB2168DBDC85 /* framer.h */; };
-		DDD8EF2F315AC545AD97B523C7D35878 /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 90B69ABD67C14F190EA7097764B5F7D6 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DF4C241BB0AC02B3360A1B6F64150C94 /* compressor.h in Headers */ = {isa = PBXBuildFile; fileRef = E841C2408971FF1DED138C45FD761ABC /* compressor.h */; };
-		DF7520A01A56E51CAFE474C844C02412 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = A2497882A9E82393DC0DCBF65EE2FDCB /* SpectaUtility.m */; };
-		E0614C42D918326AC30FA92A4361AAA7 /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 56C1388C883ECC9592080F1F4651B108 /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E0FF4EC4EAB8ABD02E7568A9C4188DE8 /* UITableViewCell+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 85E6FA106E095C348CFBAE1AA3DF9BE2 /* UITableViewCell+RACSignalSupport.m */; };
-		E12D46FEA6B1634FE67C73E5E64AE320 /* ZIKLink.h in Headers */ = {isa = PBXBuildFile; fileRef = CACD8F5BA506CEE1FED45B9C706E62CF /* ZIKLink.h */; };
-		E23945891D00F2393BCB85879FA51ACE /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D77B7E5726970936BB409415C276DBEC /* RACSerialDisposable.m */; };
-		E2716F65324D3881D61001DBCEA25C21 /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = E7D1507786C3052184A83B252D83B182 /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E28950269076D4C7BE7F03F3768F0508 /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F23B614E709D461ABF8B5E1D21E831 /* EXPMatchers+beCloseTo.h */; };
-		E2D4D8F463466B95AD64F081F874BF6B /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 104C0F5DE855DF66ACA9C5419F23646E /* EXPMatchers+beInTheRangeOf.h */; };
-		E3E26575D2A8E16AD052D57E0B08BC80 /* ZIKLogStreamEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 652B1FA7612CE62122306687D3107D75 /* ZIKLogStreamEntry.m */; };
-		E673B77A321347A73EDBA944EEFE9504 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */; };
-		E89C8D40E19EDB82D9F46BD45ABA2BE9 /* ZIKServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E3C036B04A117673C553EBA1E274209 /* ZIKServer.m */; };
-		E9A7D9E97917D57744F1C8365D77D154 /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = EAE92CC7B639F6C34CD298AA41549D54 /* RACDelegateProxy.h */; };
-		EA1840D44BAACF682563B6A69821AAE9 /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 108BA2EE35F2E53D146EFA0AB8880F8F /* NSString+RACKeyPathUtilities.h */; };
-		EA8A7F438C826291ADA050204743CB52 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CCB94BDDE3E06BA35E566623D31F24F /* Expecta.h */; };
-		ECDFF296E45100EC4849A663DD258817 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 21E2FDDD537A7835AB5F4AC1F5085CA2 /* RACSubscriptingAssignmentTrampoline.m */; };
-		EDF5DE2AD5CC3313AE8CFDDF7569B2C6 /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = FD71550502B7972F6A67439A7DFD00B9 /* RACTupleSequence.m */; };
-		EF9FB139B34F12F9443C7C281038874D /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 81BCE78B3034395FE60BA9029C9BCED6 /* RACSubscriber+Private.h */; };
-		F15D815BB87C87A49617C6D0FE854075 /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = 04EF0BDC5A75852B6A4804FE39AB2758 /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F2B010FE0A5AF96C02BF791805794691 /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6785E4D735DDD2CE69A963A4AF5EE599 /* UIBarButtonItem+RACCommandSupport.h */; };
-		F37FE3DEAC2F1973CA69A76712FE1A0D /* ZIKTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = CB0BA5ACD913C087B8677657EA94569E /* ZIKTransition.m */; };
-		F3BF232F14D17033B521E907EC1B3A58 /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA24E93A8BA894A9E5B1817DF3310B3 /* RACScheduler.h */; };
-		F3C743B8A764F65E3E983268F82781ED /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CC318C6BD5F93FB1DDD89B727074DCB /* SpectaDSL.h */; };
-		F419EFB5C4B6877B03785CCD18C65C87 /* UIAlertView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4E8E2AA00AF5EC79748FAD200C21A1 /* UIAlertView+RACSignalSupport.h */; };
-		F41D0F5E256478980067E7AC7890D9F2 /* UISwitch+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = ACE6B769E901D0C368B7418D4B98292D /* UISwitch+RACSignalSupport.m */; };
-		F583639A447D0279113154A03ADDA54A /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CFF91CAF87B0D739672F42DFC1532CC /* EXPBlockDefinedMatcher.h */; };
-		F5D10C746FA04467584A8109DD2B4E1C /* UIActionSheet+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 741EFB39BE7A75F8318655D9633AAD92 /* UIActionSheet+RACSignalSupport.h */; };
-		F72012F176EBDC3A43084821568201BE /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BEF4896B8618DC0EFF6D6E5EB97E092 /* NSNotificationCenter+RACSupport.m */; };
-		F7D1DB7410D4C4ABAE010D7EB58CE086 /* scheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FB0B910927E303746D94038B1EE898 /* scheduler.h */; };
-		F869F60FF663BBB8F588727C64C5B320 /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 666A9D1991710F8046A798389B986303 /* RACReturnSignal.h */; };
-		F878A4D111142DECB86F46B195CAA639 /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A30A796A4BA421118BCF4DA13978723 /* RACTuple.m */; };
-		F9A605F05BE214E07E34F181A5127A38 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C4CBB8EC2C46AE742FC5B4F08D2E4E8 /* NSString+RACKeyPathUtilities.m */; };
-		FA9E642CF9C0951F281830BBB9EB9B78 /* loop.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C25130F7B870BFFBA45AE7A0CC22D24 /* loop.m */; };
-		FAD0F48713D0CAC1585E03ABD5E2A396 /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 772170E58BDF4002BDDC78B04E11140F /* RACValueTransformer.m */; };
-		FC44FE9CED2B9AAF81C88E8ADBED0B4D /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = CF9BAEC6203B0F46BCD1E3A74F4F14DD /* RACSignalProvider.d */; };
-		FC7E5B8419BF03F985456C9B9DC7125E /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE3702BA7CD7C1EF918F1FFEC37B2E8 /* RACDynamicSequence.m */; };
-		FCA4D5001730886A592D4FED121DD86C /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 71DBD20BD7C22C7055FB294B58532346 /* RACSignal.h */; };
-		FD1C3C709DB8A0CEA5471CABCA2FD6CB /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = B99CFDFB66A3EF78E9CED6935D32E87B /* RACIndexSetSequence.m */; };
-		FE031FEDB0693699EEAED4ACA0CF39E2 /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 629BE5C5EFD9C1F05EBD0CFC85B49EA7 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FE686BD9EECF15BCF71F193E248BE6AF /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 44AB47B754C797DB20763B4DF661C931 /* RACSubject.m */; };
-		FE93D7EC9C3C7F35422052B2310C755E /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E3781B67B21441D53FA33F6A4AA633 /* RACEXTRuntimeExtensions.h */; };
+		00E9D36D6B005B45689F434FF9D3FD88 /* UISegmentedControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = E891EC269F94FE9E1F4DD7CABA531177 /* UISegmentedControl+RACSignalSupport.m */; };
+		017AB6018C3D9D8BB6B26D6505E9885D /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D5F26C36098801DA4B1D3E84AE8E441 /* RACKVOChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		020E0B2DFBBEC0BCF021B5E3584F0341 /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 12623E9C076D6851E80570E62515A38B /* RACKVOTrampoline.m */; };
+		021C50274FF43A6F07E119D572C3ACB6 /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = F2DAF20CA16287BD862139E0D7743366 /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02C7E3EC1E1DFDD7046BD26A67E92686 /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = A537C926D40E7E6F1CBD456E362BDCA6 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07282695806D1DFBF187BFA004D80641 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = CC94B7B5A389C054C91523F07DE67543 /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		081F2104425CDCB0915354E2FBD7E24E /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CD1A380B7532B860A6C0128C7887B36 /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0A13836F567DEBD532C377D098B09FA4 /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 399EFA25E90256DE4C1D6345BBDC959E /* RACObjCRuntime.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B4080F96E0B5E1FC475BBD05878A8EC /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1905B74F63A0AD41B1CAD8A862561A81 /* NSDictionary+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B5B1FEB06F5C4B4F8EFED45CE1CEC62 /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 52C1DFBAACDC4D0D29AB1B7A91239C46 /* RACTargetQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0C24DC9290CE12BA4911554A3A27D489 /* ZIKLink.h in Headers */ = {isa = PBXBuildFile; fileRef = E87E3E3D6785A284165237B586375946 /* ZIKLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0C41A5A97273F0C8C3F4BA7A06A561CD /* ZIKStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 80DB5EEB97CD8E83D901212B91E0F111 /* ZIKStream.m */; };
+		0D4E4F1D7D7AF31597B60B548BFEEC26 /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = A9FDD0D041D126568C997F923FEA26F6 /* RACBehaviorSubject.m */; };
+		0E0D7DCE4D1E6FF5C7B46AE7B7EA1B73 /* scheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA297289CB857150CDF7A22C104F02D6 /* scheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0E38DC5F1935686AB6B99ECA1E87EF3B /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 17EFEDDED7A7C8597D989FAA6D116C0A /* RACDynamicSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0FE5EC7315C8E0F9102DA446851CFE1E /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 67D9E087FCDD73C160E78A97F13C3118 /* NSURLConnection+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		103E5A84964DD623050FF28586AA40CD /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 841B00772D329753B4025722551543FB /* RACMulticastConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		104AFE24D01F1C4495926B40B53C5945 /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3B50DAF85EAF51CE2D43B130D6ECE3 /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		11CF0C44A36897A963C15B74C2AEC415 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A7829E600BBB4A5BA5883A828B9BBBF3 /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		12186DCF83338B6C8BFA9B682D6D24B5 /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 45719AACD7A6ED9EEF636B59ECAC2629 /* NSData+RACSupport.m */; };
+		123536D730F16EC7409B2813BD5741B9 /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CACCA3C7D4A215EB291B39770BC52DB /* Specta-dummy.m */; };
+		12EF88FF8FDBF1E87878F36C5F18FFD9 /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B47DF783A0B3BF4CF5E21E48D635B563 /* NSURLConnection+RACSupport.m */; };
+		13D64B16106AA4EDBFA0AB729A56D3BD /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0441E0AE32C0F44CE9A33ACF69DD6B3A /* RACBehaviorSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		14C609D8F203FD45194E93997EFF744E /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 08CD6196DA22FBF673CF70E9FE5DB991 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		15ACE639ECD54D13B0B7F6E5FC929117 /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 807E74E375C9672962E7B791FA604FF2 /* NSDictionary+RACSequenceAdditions.m */; };
+		1666E3FDB1EBAD4A6608D4DD8D75B7C0 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 197774D0AD9720DC6EE0303C68AA39FE /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		179F6EC775DF653A5F49456C914A32A9 /* ZIKMultiplexStreamEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 582592C4C062755C4FCCFCF63065992A /* ZIKMultiplexStreamEntry.m */; };
+		1816E2693F144D3CC28D229819850927 /* ZIKQueryResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = A828718E304242EA2A84DA1F88812529 /* ZIKQueryResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18B62BC494CBD23821B92B7FCE62C6A1 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 575E18E6D08A71A94D6B62266BAB5CD3 /* NSString+RACKeyPathUtilities.m */; };
+		18E8E38EA6FE207F73B28DCB4C2E205F /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D98D0755963DF1A845362000E59B8A12 /* NSOrderedSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		198892558E3058F7CE0AD3E922FD558C /* RACEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C5715548587871DFC3A3B71BCE2CCAD /* RACEXTRuntimeExtensions.m */; };
+		1A238138E6A38258F981090B769D1DB7 /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = BD111E8EBE043F3CD4204A51FFE005AA /* RACDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B1A93E0402B44A7371C43CB744222E8 /* UIButton+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C209576F7E761D74D71364070C65292 /* UIButton+RACCommandSupport.m */; };
+		1C73119D787A489A0AB801F59E7BA91B /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = C74D1B18DA9E5234519F4B2CF6043A48 /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1FD377AB3494FCDDA57D13834C37F9B1 /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = B27E36761CD140C7DC3B21DED464A3CF /* NSObject+RACLifting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2035B32370B94F299363AB8D2E6D72A5 /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 7072B2420C871B152E0C0C9CB4226C6D /* RACUnarySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		203C16487FC510B4F643BB017D6F96DA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 584A2A1EE1548D7617C87D56E67EE011 /* Security.framework */; };
+		209D9F8F438C5BCAE43A8DACE4BBBC22 /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FB301C423E470ABC52402A4D9C0B018 /* NSFileHandle+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21FCF58D3ACF7E44F499A0B545363182 /* ZIKPubSubBroker.h in Headers */ = {isa = PBXBuildFile; fileRef = A3FAFEC5430D762DDDD81D87E36ECF89 /* ZIKPubSubBroker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		22246F6F68C31EC00EF9E1EE812DC054 /* ZIKLogStreamEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FE83FABFC8584A26785B699BEC326C /* ZIKLogStreamEntry.m */; };
+		2239B5E63C5D2C1323D66F489F075C42 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E1E372DA6F5BF7325EA3EAF2D38748 /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		22598CDA63782A73F97254E333F9EA47 /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 104A9EDF53C855F535C4ECAFDB2AFE40 /* RACSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		225A69DEBB0E464C39A7C2DFE63C3622 /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = C7D7BA73518CF55B05357AE182F56818 /* RACSignal+Operations.m */; };
+		237FB063FB365119546C7B5006224F3B /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 249F9873EAC3626E09E6E0D7BA246631 /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259D7E10827968575982A3C448CB270B /* ZIKSpdyDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E41A919C897C4F73FBEF662DE23BAB8 /* ZIKSpdyDelegate.m */; };
+		26FD3C7E654D1F934C6DA2E1A47AC743 /* compressor.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EC40602C388ECBA787A709F0BF646D5 /* compressor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		28495910C7FBDBE1015E38A35AAE7FA1 /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 63C90E38CD895BD45DA691C1658C0499 /* RACDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		287416B2D7A394C1863261873DBD2A41 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C5BBEF39456C0740E171C5A1F4E5ABE /* SpectaUtility.m */; };
+		28AF905C86178E5839C21E9D8C565044 /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E7B3C5CC96F782C2D3FE5DEEB74B7E8 /* NSObject+RACSelectorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2945FAA75C956DD6A541EB51E42E6899 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F8FE90105F74656A451EEF871EE4711 /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A0184A78F3C7D7B2BD775036E574087 /* UICollectionReusableView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = AC0285802CDE6C920B3F48A3F31E1A59 /* UICollectionReusableView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A17721E4A81DB608CA6D4FB6F0ADAFB /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 31F08478421B679BA6E4224FB47CAABC /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A97822FA2775E9565567B8A71CBABFC /* Pods-ZettaKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 47ED70C198D1C27DB8FA33274F0DFE53 /* Pods-ZettaKit-dummy.m */; };
+		2C5D27D3BE2B20C5950B34620043FD6E /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D0FEE08548DBA391864FE3E42D81E8AB /* RACScopedDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2CBBDB7D13C945F3F738F94BD0FA676A /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E8266023F937C3457AEDD4178FAECC /* SPTCompiledExample.m */; };
+		2E4B94864F1FCE3A6BCC5D72A1E90D37 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B2E69941158970F9E10E899F014394A /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2E61C4EA8BD51397155A072BFE65CAE9 /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = E7ECB7C85249865798147B9AFCEE268F /* RACSignalSequence.m */; };
+		2EA4085745BF7F724A725AF1D6A8E035 /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = AF685F09A7816D23974C4C4CE728EB4C /* NSObject+RACPropertySubscribing.m */; };
+		2F643572309EC1DA20C19A672DC2D486 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A2CA17C9DE8F94CC438954C0FDFE08C /* RACKVOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F9D3747596E4E074C3B776949091047 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9CE303847B48B98712D44FA8CA097 /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		309EF4B10150536624C7B2263D346BD3 /* UIRefreshControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A582BDE6093D34AD109839CD6A0EFAB /* UIRefreshControl+RACCommandSupport.m */; };
+		317E5DAF107C40137DB1229BA1931AE0 /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E62896D68CA3F0A194330B49E02FE5D /* UIBarButtonItem+RACCommandSupport.m */; };
+		3212A950FA4CFC89CB17C4060980AD85 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1D35FD2393D0DD8805C9D2AE11B97E /* SpectaDSL.m */; };
+		32FF5CFF84A6A82A04381934613814F8 /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F3B77BC3EA9EC34306989CEEA919CBC /* NSUserDefaults+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		332BF7624937AE31CFC65DCCA3A72B12 /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 23613F8E6C3F6F16E151C793E6D80285 /* NSInvocation+RACTypeParsing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		337569619D6A4D1973D69E12D8504EF1 /* ZIKStreamEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 90F3434FA054544EA030674A851573A7 /* ZIKStreamEntry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		339A0C1BFF72397A705959E03877DDDB /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = C921A16385D1282E73FE8B16409CFF93 /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33CD761C58B632A4D460232C6DE3BF81 /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 06F21B162DD79BC9EED0217C3F40AC5A /* NSData+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		341D7536159B52F41598F730CC45D548 /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 27DE8DE0E8B6637BA0AF16DD87056317 /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D133B0E80038C70F6FB3043924FC90 /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = E93F5443A0C67A0886A6B4A4B9DD9D4C /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A013F13122CDB8EE962F8CB7C6FCC8E /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 501B3F7AA5171D110E467307574B11CE /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A1133F091D300CC917CF48F40CE4FA2 /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 76B498C82759B692E86E52E1FA42AB05 /* NSArray+RACSequenceAdditions.m */; };
+		3CE3B0E3217BD64C24CCC1111C6C5097 /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A143A972676B0E346EE156FD625C4276 /* NSIndexSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D730E07BA970AE078A267A1E4DB558F /* RACBacktrace.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E740B8E7A504CC5E613EFD01A9F4EBE /* RACBacktrace.m */; };
+		3E463E2B6917D9AA08A03BA8A8E74A18 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 244B27FEC7FF1DD9AF0A2F5593A4835D /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F0B5F045FD25D9F011C509EC67C8A07 /* UIButton+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F1F165027F1342BCB947165A752CC9 /* UIButton+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F774AC45C580EBF35959B2F66328351 /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A693EA863B53FF281CA1C475ED8BBD6 /* RACQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		40C9CB0769F21639775AD63B83C55A84 /* parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 15E5BA7EC5F92E9A0A10868F417579A1 /* parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		40F505E69B8595361C2A7528DDA222B6 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E0113159FCF6ECB927AF346ACD793CF2 /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		41C1F41A597FD9B0CEDA3DDA43DC91CC /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = F95948394EDCC4FDBCD734B8878D4125 /* RACSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4205D5CE9C3EF7BECB20B1D2367571CD /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = DACB96CFE80FED9F7622FCED70899ACD /* RACSubscriptionScheduler.m */; };
+		4231743B6C143BDB4A5FBB032E6D3799 /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 91327C47AC2D5061AC2D328304AC9151 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		423A2372975055CBCA1BE8E83E6CB282 /* SRWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = BBA54E8CE2A5CE2CC0876E77600938B9 /* SRWebSocket.m */; };
+		430CE433DB59FE090A8CC6AFCFA43337 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A27A1D35EFB8CAC34829886314503F4 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4383E0DB1B07B9EB3155EF5D5F27C7BA /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C3FDDD4D50E7B52D3730ADD103D1A60 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		43A1104CA0C628C2F693902EADA32B8C /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = F00FC1BA3B556A2035D50CE2493A93B9 /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		442A2D72D984E809910A5C7261488849 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = EEBAFFBA3116126B88A2E528C1DA6ACF /* SPTTestSuite.m */; };
+		4544E360AC49B1E575F1CDD0A4EBCA68 /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 724F059E82DB0D20ABEBC23776B78778 /* RACScheduler.m */; };
+		454C8D24CD284E983BA4F6178E1C592B /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = C5BB01A6E736EEB18B3787A032A944B9 /* RACImmediateScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		45636CD2498FE75E3AEAF01E6DA06800 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 446F933EE90F1244D8D8CA265DBAEB44 /* SPTSharedExampleGroups.m */; };
+		46F312CBB94BAE62B58D3D7AE28E8DBD /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BBFB976DB961B4EBC3D4CFC38C8953 /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4792EF718E0EE4760F759548B92426BB /* UISegmentedControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 76259B99B9234E4C2F2E8CF21AA70293 /* UISegmentedControl+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		484AE62683CEE1354AC53E85EE20F086 /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = EA8E021EED935A5BC1072A2C2F1D71DF /* RACSignal+Operations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		487899F028C39C1A518547A1AB2F625A /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A6F3E9B05DFBFEF1ADC6E414D21600B /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		48DCFB9A3439974027B2ADD98064E147 /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = B73C8F282C3073E55887901D2522015F /* RACIndexSetSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		48F35EE31CCDEE774A40DC49DD9C90E1 /* ispdy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E7508F0A9C97F84ED08A362C610BD77 /* ispdy.m */; };
+		48FF6CD26B33E6D07AB3D96B304BC5B8 /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AB7957E12585177C35D695172EF7ADEE /* RACScheduler+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		49EFE75BAF060A33327F3CE8C18436F2 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E57C81D7CED70EAC5FCF8435D6CADC0 /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4A145A5D08363FC3A99FB837E8D4595A /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = F74B076165239E6B1C2A4B47523C4E99 /* NSObject+RACSelectorSignal.m */; };
+		4ADD3AEC4E63944EF2333DB051403C36 /* ZettaKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 793A0F5669E52E6DE5E9953A9D1A4C51 /* ZettaKit-dummy.m */; };
+		4C2666EDEC551C904FCDA9CB8490F454 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 47CE1F61B9188398391D67DF09B0C0C0 /* RACSignalProvider.d */; };
+		4D04E30E11B6CCC821CD59161A4BA11C /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D9B11BD99BCF95BA193809C6D3C65FA /* RACEmptySignal.m */; };
+		4E05B5F0DA3C33A8A78D1FDDF940ACDB /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 1577B7A21955232EB2572EBB20B0D63C /* RACStream.m */; };
+		4E283215B682D67972E9267559EB0750 /* ZIKSpdyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BBE9D05E4F9814E5F26DE9EEA47626B4 /* ZIKSpdyDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E4A734703008A37387722653CFDE43C /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C3FB06352F57BA378EE5504B0CF015A0 /* NSOrderedSet+RACSequenceAdditions.m */; };
+		4F64ADFA8D627F23453CB0DFF464B947 /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 21AD5F2D89A56E7D9D50A91C60983476 /* RACDisposable.m */; };
+		4FB93B5770B13BBEF4F6577EC27587E9 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 9713019DD4155A06917612BBB9819D0B /* RACSubscriptingAssignmentTrampoline.m */; };
+		4FBF816B10502E1FEB94E72CCED27611 /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = B2CEBD589001912EA1B56EBB19A47074 /* RACMulticastConnection+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		515363DB53423930798EFC7ACD9A0F5B /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = B5714F791BD7855787CD63418474CF0D /* RACGroupedSignal.m */; };
+		51E0A9299B669D80E948292EF7E909CC /* UISwitch+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2E2EB23E9C08AB9237C9153C153BD5 /* UISwitch+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		52A757E5F1E1C205F05B0C903B26B8CE /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = FE90FFC1AF01086A63A326DB289CBE9E /* RACScopedDisposable.m */; };
+		539F1A118B2C8A2D2051E14EFD483266 /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 736866F02218EA68B125AE95FC10C3A1 /* RACSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		562BE99A6F630E709218EB9B3CF36E90 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FD3117EE1D83C2433A050FAE363A02B /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		56BA73545D71469B1351E8E5E52666F1 /* framer.m in Sources */ = {isa = PBXBuildFile; fileRef = 08E93F192D817B152ED152D748CBF14D /* framer.m */; };
+		5779A991DA5DC2F95EC3A27E38846DAF /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DFA37545B55B0300E856938EB73FFC7 /* RACDynamicSequence.m */; };
+		58C9D0ED39EB8B217D58BF637FD29E05 /* ZIKUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = D9FD2BDE956EE1E1B861F22E71D8DFEE /* ZIKUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58CAE9CA550EAD45A5E1858CCE07EB46 /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 59439829E3C4E56FBAE4F00E266E1A37 /* RACEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		594FF15A9A88844A7D2A4301179EC719 /* framer.h in Headers */ = {isa = PBXBuildFile; fileRef = 537B29BAE46B93F5C1FC44A01BC2D413 /* framer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B3A877EF264E6FA602FE408AD940FBB /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = BCDE9C15A3117F912F32E8E2CF695BC4 /* RACScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BF3BBBA546C806349C163EE0BA34154 /* RACEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D0FF60BEAF1393227B134181A3B434 /* RACEXTScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C424E6B9AA0BCD4C6A32A4A48876EB0 /* ispdy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA8C11328E7004806517437231A49AE /* ispdy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E8F33E777456DA63CA2D902508A9058 /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FF21B4E1BFB58DEEABA6E5FA717628 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5F6D96E64F890BDC4A75B73C3D50A0DD /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = D04D8CA58EDFE213709224E5F95FF668 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5FE8785938407DA6CAA2AE8B559BAD84 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F50DEA32B696B39BFDC9D19F8BA3D6D9 /* UITableViewHeaderFooterView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		601C0C80E23E97A184E782E2A67B6B2E /* ZIKServer.m in Sources */ = {isa = PBXBuildFile; fileRef = B9AB7070685988A22D4F17677BDDCB19 /* ZIKServer.m */; };
+		60C1ED751BB20883F9A265CD00AE555B /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8871C1DA358494BCB93C7EF46B001011 /* RACErrorSignal.m */; };
+		60D3CCEB5B53542228790ABD8885AF42 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = DD122D058273E923AC4EEED3FD82EC39 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6111D55178BA9CA2C0418F0549A79CE5 /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = A91C258A43D5ADFF9475D12895F61411 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61732C1B868F27ECC7FA129996FF4283 /* UIRefreshControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = EEED1796FF1FF9C0FF40280379C00BC9 /* UIRefreshControl+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		617734CFB46F07A85813365ED3F84E36 /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = E347C79F678AADEDC3D049EB0731C9E2 /* RACSignalSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61856AF4DF00DE7BA14D9AF984B3AF0A /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B36EBF9EC8D2879793B47CBFF2EF1DC /* RACTupleSequence.m */; };
+		62185A59C2F64AB15D20BCC0AE6C065A /* UIAlertView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E8CDF624776F41717486C9D5AE245F7A /* UIAlertView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6229FFA2E624EE44EC0FEA533C7E717E /* ZIKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BAF0ECCC13841E4CD4C8AF3D676DFCC /* ZIKSession.m */; };
+		62360FCFF842D9E73CA08B94F1713FD7 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = C7207F073F97144F41D3C4EC324DC3DD /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6303225F7695C870841D204AD525DFBB /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F3586C221621D26A3BB8500E26980E4 /* NSUserDefaults+RACSupport.m */; };
+		63CE42D592F8CC7F5FDAC6467DA97700 /* UIActionSheet+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 59F70B8A4A66AFA5FB397B79FC0491C0 /* UIActionSheet+RACSignalSupport.m */; };
+		63D0CD4F0FB5A6103E1DDB46E876CBB6 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DD35D9531E8326FA3C2C171D3194A51 /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		63D9155454E68888987DCC54A8D7ED01 /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F1B078832036E8314B365385207243 /* NSString+RACKeyPathUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6426A3440967FD3FE00EE3D45DAAEACC /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = F7AFDE4EF1DB9F469D6328E574A3DA71 /* RACCompoundDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66081D3480D1FA028C4DE2344BF616D4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */; };
+		668EAA1991EF86669F419C4CA7817921 /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F50671E063EFF82A71D6980CF8CC780F /* RACGroupedSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6924E116731D7079958063A3EE0781ED /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A5141ABB6A0DD0A189514163370DE5B /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69363A59A4E2FF95D6A62AA88641A20A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 428B84E579C78098D283602A1DA9F6D7 /* XCTest.framework */; };
+		698934DD487D9CDA6350C3834E94B6D2 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2730914A537D4010675370C90905A9E0 /* RACTestScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69EBB956302554EA37775F4D806BC4DD /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 4399297F896080C94A46270683832A2D /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6A4E3ACA285A21392936C110E7EC91F0 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 09DA554BAD2666EEEB3875559C732A3D /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A5B04301BA04CABCAB2FFF304BA41C1 /* compressor.m in Sources */ = {isa = PBXBuildFile; fileRef = 95B78E7EFAC5AA14CB23E9449EDB6D71 /* compressor.m */; };
+		6AB877F558569CB7B23DDCDB4AE48CA2 /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B432DFCA87CF1FB63A6D5DCF79AF84E /* RACmetamacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D37BEAA1FC469C3582CACB4E9766502 /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 629F9220AD47D610FB0EDF12B1360A90 /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6E426A235DED5D5EE942B3FA58A140B6 /* UIStepper+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = E64DA99843772788110E16DF50E93BE4 /* UIStepper+RACSignalSupport.m */; };
+		6E43B327A364A177C2F1C82E4BF1E574 /* UISlider+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 42F6556ABDF624E54F294C42FC4849A8 /* UISlider+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6EB2498C2AFB1DF8555CB7C1EF89CA5C /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 34330769E5701AA9202A35B2BBDFFE51 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F4113A837A4F458D1FB1C1174635C5C /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EFD47E28DABDF59B64F97718E9F69E /* RACIndexSetSequence.m */; };
+		6FE4A3073961CA57551263A55E1E798D /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 428B84E579C78098D283602A1DA9F6D7 /* XCTest.framework */; };
+		70545E4EA86C6E593A2A9F6731DA8F6D /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = A85C90F4299B095EBE7AC5152BA02CAA /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7068DAE4C1AD8CA3551012962F827178 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */; };
+		706AFF72C83746CE8078DCF8E57BE1AF /* ZIKLogStreamEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E4B3F96872494CD3F5BD32B2A635F07 /* ZIKLogStreamEntry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		712B8540947B6861B2B794A840329FCA /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 51625C5FA086FBCD75EB57ADEF8462DB /* SPTCallSite.m */; };
+		7310778D17E2311C22F202B7352A2849 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F890F72C0602F1B7621CB4BA83BF8F0 /* NSObject+RACKVOWrapper.m */; };
+		7436C602BB1CA7C91560C28DE749357B /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = B7AFF5A1E81FD338B8434B90A6FB86AB /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		744266F2FAF0D16A23F6124D28347572 /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5051018961F950EBF8F277B64ABB2C0B /* RACEmptySequence.m */; };
+		74707D5ABEC55B3084F52C40A4227B06 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A0585CECF89D799A21C31A5CF61819C /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7537CBD4D00339DC964517785E52046D /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D7FC17245AD1982B1BD013D6BE7A23A2 /* NSString+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		753A3A0F59A082DDB1DBB70315BCBC01 /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2E91920AC3F02EFF7D63150776BA92 /* RACTuple.m */; };
+		76331E71086C8CD5118A69B046D8F0FB /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B46B65BA10DB7C108ADBFA93C71A0B5 /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7661E0854F2F6695C39FE1D06084139E /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D7C60040C68FBC58D2E7DF1B23E69C65 /* RACSignal.m */; };
+		779CFE8771E1EF63F1313ABEBCECAA4A /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D318E89B99D38C5D403C0086512FAB /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7833659CFEDE82D96D3C1EFAF43D3726 /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = F4D5E05A7D460BD2A65B28AE99BA1548 /* RACQueueScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		78DE5C99258885DF3CEF9AD84AEA5AC9 /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D385992879D7D7C6C5607ADF621CFA25 /* RACDynamicSignal.m */; };
+		797E71F721305E25ECE022AF2EB16925 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CC7B09121CC961047AD9C78F37DD61 /* NSObject+RACPropertySubscribing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79E8D9A2AE13C401A691A0F5F5193AB8 /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 7159390A93C56E54C7582B79460869BA /* RACStringSequence.m */; };
+		7A0E82DE694B41C32A134705DCF9CB82 /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB02C0E54D42481A62AD3089B3401E7E /* NSIndexSet+RACSequenceAdditions.m */; };
+		7A64247782D5E9CA0C734509DCEDF5E7 /* scheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 489B54233C8143CF4A90AC905FBDE827 /* scheduler.m */; };
+		7AC91F55DAAA2F0223A97BEFF8BCAF68 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = EC2D6A8C0E1E4016677E28DB6E064CFE /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AF513C2EE0C3F942A8C3583CC1E9E3F /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B9DC7FE487BD7419DBC28A08E1CDB4F /* RACReplaySubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B76061E0ED323432A88EC4322A27464 /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C97FF8DF5E082F83910AA7BE2CAB1D5 /* RACArraySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BB41D063245E855EB861C7B4487665A /* request.m in Sources */ = {isa = PBXBuildFile; fileRef = 90592CE8E298086EEA9D8D1CCD214365 /* request.m */; };
+		7BDB187E770B1DDBE63EFB16291A3A1F /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 24B1817A010990A13217A95AB7ABAD59 /* RACCompoundDisposable.m */; };
+		7D848B8E3211F93AA74FF1CF285E356F /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 94F844683B588ECDCCAA89CEC01236E8 /* NSFileHandle+RACSupport.m */; };
+		7DD14CC7F97E07B8C3C16F4F24C8C561 /* ZIKRoot.h in Headers */ = {isa = PBXBuildFile; fileRef = 87B68F4BCCBBD414A09F0FA3D01AF6F4 /* ZIKRoot.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F550437AC1E890B01FCD43EFC962F77 /* ZIKDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = C22079DDCCC94EA5C5B5C9DF10ACC751 /* ZIKDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F626CA39387F4C5EDC10B7EB3E86912 /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = AAA71D1183F9825A15F96A30A5565DCE /* RACImmediateScheduler.m */; };
+		7FEE0E8D094D7BCCAC7129473EE05ADC /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = EC112ED3538D9B1022DA0CFCD0AFF004 /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		80139AF056C3EFA1DAF8587D55639B4C /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C15EDA1D8F7B024C74EAB84E6A53A6F /* RACEagerSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8059E5674B08670B0A002D564FFABF44 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E8898FC5B43DD1F1C4D4CCB86F47FFB /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		816727D4C291781BE28895B1A1513630 /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = CEE15BB7927F71C5EF0D9944E49C3D15 /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		843A633D759AF5A8C9E8A27D4B82CE6F /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 90488EF47B11B7F603A859F3742766FB /* UIBarButtonItem+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		85607D78C803828DD824D339B53F9F65 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = F7E2504F66F29BA0C91B7EB79EDDF056 /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		85AE749E567451A1133BFD294FBAC7F7 /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 83997E2AD682AE9A1F41047F2B0EFC47 /* RACQueueScheduler.m */; };
+		867CCF41E1A21E4D66FAA17AF58A158D /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 1164F0FC120495823065569EDEF28865 /* RACEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		86A21DEE9BB2F93B78E455B41EC0C100 /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CA3F42064F3B1D70243E0FB95B971A /* RACSubscriber+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		86B8749C1E25DE121BAFC8887FEF7B1A /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D437BACC065C49426D20FC1069D176 /* NSObject+RACDeallocating.m */; };
+		86DEC65F69CA7A9EDCE07A396E8463A7 /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6D71F184E95740920E1C34D7E76253 /* NSString+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		872948DAF79618AD725E0BF364E5DDD4 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 4803A2B67ED54424ADA2CE58907A1261 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		873BA3D71241B46B6B80B6586B4B48BF /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = FD1C69C1991C3CF4E814739A96FC8286 /* RACKVOTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87F267559642F8B0732681A85017A3C4 /* UIControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 7265403BB611452813B830384C77018E /* UIControl+RACSignalSupport.m */; };
+		88D782327ADBCE0A7C3FC4AB67C22A96 /* UIControl+RACSignalSupportPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DB0504CF54F499FF286E6877F3115F7 /* UIControl+RACSignalSupportPrivate.m */; };
+		891FC9F5C703C1972351A9C680823738 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F25A9DF41A6B6F8A96D43FE0C734D55 /* RACUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B31BEACA5CB98AAF5CA41765D52D325 /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = F28104D710F12599910B64C3A4461F10 /* RACTestScheduler.m */; };
+		8B52A2BEE079E0A1EEC91C6D6C568837 /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 9329180DD4BBB481648E2F4FFDE51D81 /* RACEmptySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFA22E78C0B21D091CC85D76779FF88 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BB5F805E6EE3C8F6F9A4BD84396A798 /* common.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DDC1E0DA0EB3A1A891D8E01240490C4 /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 76B5A6511E6248F836C83CEA0678F8D8 /* RACKVOChannel.m */; };
+		8DF90D623F7F9015EEE9F1D7FEE7E053 /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EFED9162BA2F199634F6FF686FB2B9F /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8E4E1AB8944FF01E54628BCCF179C56D /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = C95BC3D2F89DB47545476BC0D3F87139 /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8EFC503E3E3152C8319F86FFF255B4E3 /* UISwitch+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 62FFBD32F4A55C1B67C8700F14AD271B /* UISwitch+RACSignalSupport.m */; };
+		8F1FC7AA6320D68EBA83859A4341B43F /* LICENSE in Sources */ = {isa = PBXBuildFile; fileRef = 24D95EF022E9831DEC806BFBFFBF4ED1 /* LICENSE */; };
+		8F674582EE71972EE60EFD96C1F173D5 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CE79FD9A24A5AE629B23FDB46167AF /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8FB1873754FC4FC0F99AAA31B678B4C1 /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 9510AD3BA0C99858102DD0BA82B890D8 /* RACEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9019F9233E2A8B04A82C1B8D0274F09F /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 974A64EFD437923F338C35D754EF4F14 /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		914D7E610C60E9313CD071F09B4E230A /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = F3AD4536DE30D8EA87417415F662E8AC /* NSInvocation+RACTypeParsing.m */; };
+		93B0663A8A755A0D376F8BD624779B51 /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 0064A5DFABE906B13C10F14A5268E78D /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		956FB3AB698AF3DA776A9F24AA79C229 /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 082C0915AB6CDD2D1AAD0DD48BD1A0AF /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		97E91EC237B8623D895DBF6092034AD7 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D978991DE367B110C9D609D627C6077 /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		981252E61DAAE4130C882D5027950F07 /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 87446A059E2B640EB4228A281551157B /* RACPassthroughSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		987AFB493C7CA3FFC13970122FECDB9F /* UITextField+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E928B4F0D64608EEBF469AFCF96AD9D /* UITextField+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98BFCA3BAAB97B5C65A0334F6768AF58 /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F85C712B1D6545F7FC0D5F7A09B7E70 /* RACTupleSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99AFB589293DE00826E08212E67BE9EC /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 381EC98E8D5A8F00FF27E6A6052ADBB9 /* RACBlockTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9A81AC7F2D86E9A58B30494D3B7016DD /* ZIKQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = EC891F6742F11F128292B7A48860CAB4 /* ZIKQuery.m */; };
+		9AB6C7A774669A1D6765FF1632FA9EC3 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 1D5EA101D113472F861FC70F08311BAE /* README.md */; };
+		9B546D0F895D9B5A8316B948CEE95C77 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = D910F4A0EDA5C55A84D8370680C81F3D /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B7D74C5C8BCBE47856A23547CAF4775 /* ZIKStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 5839544CA403ECBB8310740DF5C90EDB /* ZIKStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B88BAAAE17DEDD02052E5D81C22D13C /* UIImagePickerController+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = E08532A1035BC677EC5CEB789B819C57 /* UIImagePickerController+RACSignalSupport.m */; };
+		9EED295B9A802E1E538352864C06B076 /* UIGestureRecognizer+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 621D4D723DBE7D4218665E0AC1342C51 /* UIGestureRecognizer+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A0B247D8D1BC3D5647750CDEA5FE4DDD /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 21BA92377EADEDD7FA95EF7366D46690 /* SPTSpec.m */; };
+		A206C79A89B961A3497AC97A45046548 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA8575E86EB20883AF962870025D142 /* RACChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A26F992E8831118311F3DB7CB830595A /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = C45AF9724992B8B796B18BFF456E45DB /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A2E7A454C48BEBC5AD3D190319F5F97E /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = C6AB7BF63C59F61D644EEA4EE631F35C /* SPTExampleGroup.m */; };
+		A3818B2C6C0B4A1A97E1FD13619238EE /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B452F53FC4F7777F91C800ABB6DE335 /* RACTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A448B6601A17181B02F2EB745CDFCB0E /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AF69967B99B1113F1F14D00B282D8FF /* RACSubscriber.m */; };
+		A44CCD9D1048F5997DAFF1F76F690428 /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C085E99658A5F1CEFB72E60107415DF /* UITableViewHeaderFooterView+RACSignalSupport.m */; };
+		A456129FCCD2D28C4818F1A3D77D82BA /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = C7FCAF3EBC70368E629E896F4764C1F7 /* RACReturnSignal.m */; };
+		A5696F6D6A65B913C0576C508723F464 /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 814EF461030D50A1EC6A00CA40AE3328 /* RACErrorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CBB8F1FF36B9AAAE338F47FA0C6407 /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C70DFD84E18AC5029210185A3C7E47B0 /* NSSet+RACSequenceAdditions.m */; };
+		A65C491577A425AF82C53F4A40A0A24B /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 23AE5BBF485C910CA22290047D3E51B6 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A6854D311D55E2BBD8BFCE4E82DF3EA9 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 03193F0A865EBC01C80201BF200C51E2 /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A7141BC83638F4B38D4D312BAE3BDAC4 /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BCE3CF1AB18B956FCDAE546831DFED9 /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A7157C2DBB63FA5B066F044D183C51F5 /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = CB637AFECB15359174697DC08B4322A9 /* RACSubject.m */; };
+		A7FBCAEE72BA12BDF7CECCC1442C060A /* UIGestureRecognizer+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = FF786D8F7275F32CBABED40CC560AB48 /* UIGestureRecognizer+RACSignalSupport.m */; };
+		A7FBE4574FA8053666E20CF5BBF86DEA /* ZIKLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 837054C4375CF39A28CDD2D63B5782BA /* ZIKLink.m */; };
+		A8490A46CB5206BCA5F90FCFBA2D731E /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 771858D40C429A9E50FE6C273ED9BCA3 /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8A1AA0CF6E18820F61EAFFF5DA5DECC /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = FCBBEF829D436ED24146C3AB1FEC7F08 /* RACPassthroughSubscriber.m */; };
+		A99E2451E77F4FD058B409887CAD28AE /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D783B3F6E90DBF51FE96E0D36EB7FEF /* RACEmptySignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA548C9C8DEA653FD75BAFB139C0AB64 /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = D5497F7C0AD1EA4BDA02871EE42B3772 /* RACDelegateProxy.m */; };
+		AA7B402D31D86AE5E3DD083408311FF1 /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 451E130E882DA10D9DEFD312555F059B /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAE75938ED3DD46BC00352B82D7CA890 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = DCBEDA66EAE2B416C80E2DA212FC4E51 /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB1D6408D48F6ECF3FCE553BE73961F5 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F60CB0C182EC5AFC1AC0CBF56BCB21A /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB757776E1CC6453D71DCB93D77AE0F8 /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 000F856D7101A8BC6B178670BC643798 /* RACEagerSequence.m */; };
+		AC06F361ACA58CDEC16B4C666E4238D0 /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = F45459ED42E2368FF604F6EDFE0DC4BC /* NSObject+RACDeallocating.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC6D16F5571EB62AE57B294234124C71 /* RACBacktrace.h in Headers */ = {isa = PBXBuildFile; fileRef = 11BD458135FCFC30F9EF63C65CEEF3C1 /* RACBacktrace.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AD14E5E364EBF0A6EAA951D8309C94C5 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = F707E0E883A4C7537200AAD0D1C70533 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AD6791D14732A3C17164F61CC72FFB0D /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E3E923494CC00A096130838B50D4926 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		ADF4A57DFB19E393DA00857274112312 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */; };
+		AF28821E25C5DFDE9BB6D24F0DC1CC6A /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E6CF1CA72EFBF01AC43ACE22B33C14F /* RACMulticastConnection.m */; };
+		B00AF4BC0674F7DBAE76380325AE95CA /* ZIKDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = F733B8A74D4C6543D511798962A5F09D /* ZIKDevice.m */; };
+		B0F05879F1187D4BD4E72BA3B1F358EF /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = C730C42C7E0A20FBC8D5C14FD1F2A2D6 /* RACEvent.m */; };
+		B1B1C39CD03A2D0856BCD68A6D935074 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7807F865B6F9BCA550F3FF9019137099 /* RACKVOProxy.m */; };
+		B27D35C3718F619B94F5386C72FDDCC5 /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 474D4012450619FE1462FE15FCB301AE /* RACSubscriptionScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B329F06806AD33648410CB4A60D6181B /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = F41771A261A6A0500C7457CD20437474 /* SPTExample.m */; };
+		B33234F432A72D5E8B65694AE937B78F /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = BEB8BD3218534014ECCEBCB5642CC119 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B3FC415CBDF5FB64EF7776A46C13FBCB /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B29209402CC5FAFCD53FBC0B40BDC3FF /* NSString+RACSequenceAdditions.m */; };
+		B40288245A9C8CC8134DC95B3C30FFB4 /* UITextView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C974A4094111CAC8D6AA56AE309A3EC /* UITextView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B4D3B8EC0B76DE2F99C27186F94D830A /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 25F6B15249280120AA30CF1F70DAB036 /* RACReturnSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5C1AC7DAD518D7C9352974466822878 /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = BA38B6970BF21C123385A2564938F23B /* NSNotificationCenter+RACSupport.m */; };
+		B80B82D1B951E4337F43E9A24DEF10B7 /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D291EB38672207FFB7F6315E56AE2DE /* RACStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B89A6BEF0EAB11CC945337042434B532 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC0985E7655086F972C557018F0DA42 /* RACDynamicSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9BEEBCA5B83DACDADF5BBA51B8F5D27 /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 06E5982576957E4346DB04D83B0F8783 /* RACTargetQueueScheduler.m */; };
+		BB71013946E3F49F35680565F0E0331E /* ZIKServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 15B84CF3D4D844B8D622A71195CCF4DA /* ZIKServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BBC9823C155128D9175686AC6356B0EB /* ReactiveCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 374914A0326FB605CFF021BA226097A4 /* ReactiveCocoa-dummy.m */; };
+		BC8F67A730644617AC7638EA55BBD17E /* UISlider+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D4F8DF26508CB420029A380B8B02444 /* UISlider+RACSignalSupport.m */; };
+		BD30B724A71CF5D6E93805B7615EC79C /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = E1745B36AEA70DA46E82E11A30A5A1AA /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BED8C899A74A1448722C8F3C91136835 /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = 460945DB57E6AE36593F74CBC5E10972 /* NSObject+RACLifting.m */; };
+		BF933D54645AEEBB5D9B9898F4090AA2 /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4311F1F4907F6B5122084AB91187F1FC /* RACScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C01997BA0634D6A23EBC22ABCDF32B52 /* UIControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A56037B984AFB4991EEF77C5FE65301 /* UIControl+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C20A1001DEA50D29452E4D48E37956A9 /* UIAlertView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = EEEEB648BD8D739F858FB6CB3861E4C7 /* UIAlertView+RACSignalSupport.m */; };
+		C2398ABE94065D7EFA1D806E6EE6591B /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B0CE3A030FB80A882D8B46543CF5655E /* Pods-Tests-dummy.m */; };
+		C2BFF99EB859FD7056CF72C4850693D1 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = C3C2081458CBEC4E0C8CBA4FB124389F /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C2DFFE2BB693FEFEF97FDE6516273C42 /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = BBF9A6B773BD0568DD8D50E62D6B86B3 /* RACValueTransformer.m */; };
+		C3D134C629E261CCA089C0DC4AEBC007 /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = DCAAF1157A4C0916378424BC991B201A /* RACSerialDisposable.m */; };
+		C4C1D1177A9EA78ED5981B5038AE3776 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */; };
+		C6671739E8C5904113586F8BEBBC9780 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = B60BA7C5006EE0F1EF3558CEE92526AB /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C68CEA077E3E8B3020BED7465AB511E8 /* loop.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C05DDE8D0DD9249BA9BFB26911B3EC2 /* loop.m */; };
+		C6C1D3F9E43C370FF403584064C22EDA /* ZIKPubSubBroker.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D56DA445AE22C32F12F90665904C329 /* ZIKPubSubBroker.m */; };
+		C8AEEE05730CC62F5F4FA27A7ACE2008 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AAFF20402CE303809D9FABBAD5C779C /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C98F5401E5C1AB6512BE50C3B7CEA9BF /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C12AB40C0C3AE2A1ED9074978957237 /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C99233CEEC3FA82B7EE8DD644266221D /* UIStepper+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 5042AA968A0ABDBE3871B7622F78EB26 /* UIStepper+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAA01881F44EF97CA7080EE4CE991803 /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1344906DCF6EFB4829EBAAEE7ACEE2 /* RACSubscriptingAssignmentTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAA8C4EA98297C539FAB169DC8162A81 /* ZIKUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 2118C5E5E0E5926EBB1A7A4DE809F68A /* ZIKUtil.m */; };
+		CB08C9C83ABDBE55762A423ED48491EF /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 440035A52587B47DC900191DC2BFC430 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		CB57793A8FF6E82F06F1F65ED0065D44 /* SocketRocket-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A060474D7A11CF8A75C4BABE1F5A6ED /* SocketRocket-dummy.m */; };
+		CBBD909EA888F0172F0B85E392A360F7 /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = E2EAAD5DBE06A90DC1F3840D8D719E8B /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC2BA9C7F1B9DCB4949049B82E78C685 /* UIControl+RACSignalSupportPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BE9DB8559FD1A1D949D1001463622D3 /* UIControl+RACSignalSupportPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCB7B7C373368E7335588FF9E1BB1B9C /* UITextField+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 819F476B597E5250D35F6C4E679C248A /* UITextField+RACSignalSupport.m */; };
+		CD2D6E315BBB7AB19D357545ABAAD9B5 /* ZIKSession.h in Headers */ = {isa = PBXBuildFile; fileRef = B969DFDF184326B64EC3307A748DC45D /* ZIKSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CD8B5A6C1258DB377F7CC85F6D8929FD /* ZIKTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 95E262ADE94CCA799941A74055041B23 /* ZIKTransition.m */; };
+		CE560DC6FF3DC7FEEEAA48F1BED35A43 /* UIDatePicker+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F250AC55FCD6D4FBC738496A747132 /* UIDatePicker+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CF95446EA555B49150EA7270096D78B2 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 38FAE971B998F0B35182A3F66E41FA1A /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		D14C9295D900EEF68C2C6A46AF17DD7F /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E90A7CB9AA7BD637450DFD338647C738 /* NSObject+RACDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D19DD5995143EB8D46F5DF78942A03EB /* UITableViewCell+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = C81DB42D73B489E1BF1C967655FE2481 /* UITableViewCell+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D1CC4522173639482DE73AF66EB73E44 /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D37009F319795E9375273A4713949CB /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D27B4B68B850F23601D68A164BAE1D50 /* ZIKMultiplexStreamEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = DD724BBF5981B808BF260B8FB9864231 /* ZIKMultiplexStreamEntry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3C67933C1FCEED135999EDEE8141798 /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 23C8257ADCC63FF10D8315B65EAB1C30 /* RACStream+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D3E3068562B2235BC6453DC38B4EEC7B /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 157D07568C7D5456875136D836176D39 /* RACCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D42799488F38F2DB8A580730CEE13CE6 /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = BF9CC99DB0751C60E65BCB260970D6A0 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D46E5EABF91B6084F9BB9BA5C89A85E7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */; };
+		DA90D31E66525C183D17099299D1B69F /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D521BB6601809129D7B55C9FD759530 /* RACUnit.m */; };
+		DD33E05235E9B5875250B93D0E7F56B0 /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B441EB635414EDF074BAEF21B2058BD /* NSObject+RACDescription.m */; };
+		DD57EBD90B0BBFCC7E6D8FC007AE1A05 /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 51F4BDC233123AE3A9EA3A038DF8D2A9 /* NSNotificationCenter+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DDCFC6EFB7D833E758BD8EA08A79B91D /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 87F7C8BCB22AD58A12B1572315D52A0A /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DE4648DA426DFFE4B911BFDE866E0661 /* ZIKQueryResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DAB30DEEBE9F3CB895D58BE6C2D5CA2 /* ZIKQueryResponse.m */; };
+		DF3621D5D7AD0092747EC1FD11E860EB /* parser.m in Sources */ = {isa = PBXBuildFile; fileRef = BC093202904054601561F25DA7534E44 /* parser.m */; };
+		DF4C193E624B6C52915C387A78844678 /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C586B801A1C62272EEE24D11EF15743F /* NSString+RACSupport.m */; };
+		DFF580AE359407E841BA8D8DDCE6E299 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = A4E53D0271C74B39CBC63B4B42151879 /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E06376455C1D5E45B97ACDC5438FC15B /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = 583D976916D469215A6FADAB0FBDD73B /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E15BB51E6D9F6834DD5E7762243C8E1E /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F059BE23CB9165E492C5F0D8CF842FB /* NSEnumerator+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1B3EAD1F5549963CC9C5758A0D4C371 /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = AC59CA58F43E0327E7D352F6665E4E00 /* RACCompoundDisposableProvider.d */; };
+		E2EBD18BA89D3FF648947DF31FA12D44 /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F5634300B7CB65BBBC645113ED9A7F6 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E320C67F4E9AE79753C9386EC8D788B3 /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 11FD7D57E6869773BA8B6976BDE365CC /* RACCommand.m */; };
+		E35422EC13D1B1FF09C12375029AFEDE /* UIImagePickerController+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = CC2DEA8F4D7EE3348CEC9E09385CAC55 /* UIImagePickerController+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E537FAE29464DAB3AD1B5D1AF9856439 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94E72A5AC84C6C7261171D59904427D1 /* CFNetwork.framework */; };
+		E867CBF850D20C314BF4BD790432455D /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = C5BC04C23BCF94E8959DFDB04A78D5CF /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA5D9D810ECB1BA7D45DA5C027B32904 /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = E62CAC8621BAF233839416A17F5DB8A5 /* RACChannel.m */; };
+		EACFAFCC8171D402794171BDA96E6B32 /* SRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = DB622FA4D3954B9D4C362A81892A87CB /* SRWebSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB779FA52BDF5199781320DA70D4C46B /* UICollectionReusableView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = DC72857955E930399D1DBEBF2586F413 /* UICollectionReusableView+RACSignalSupport.m */; };
+		EB7CADC7426A507E1DC4495D7B5C4033 /* UIDatePicker+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C57CA92BD28AAA882016E954BF09B40A /* UIDatePicker+RACSignalSupport.m */; };
+		EB8AC483B4160EC60604FAA21FFE4778 /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 452246F4F6CB6AB7740F5AEF7ADA1527 /* RACValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EBAD7BC6E37C0B4B04CE1D05A6D60B16 /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E010C8D6AF601EA5598C256C26939290 /* NSEnumerator+RACSequenceAdditions.m */; };
+		ED9667511E18D13D2D045BFC84692563 /* ZIKStreamEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 503567FA56A67261C464A92973F0D03D /* ZIKStreamEntry.m */; };
+		EE52A320EC3155B114104E06396D1B59 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 85680E6ABD2FF8667738D7D965B648DE /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EED1ECA163F48E1E59FC80EABCFFE37E /* UIActionSheet+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E804BEF49DE6021B2954A1A5B5EEB4B2 /* UIActionSheet+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF3359AAB00AAD69C136919523F141E6 /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E5D7FCCFEAB0E4BE322D6EDA4EDFD65 /* RACBlockTrampoline.m */; };
+		EF3BBF2B2591678A29D12387F238F28D /* loop.h in Headers */ = {isa = PBXBuildFile; fileRef = A9223D9DAAFC739BAF84DCA384433E3B /* loop.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F02A759238E0EFEC5306270AD75F2F30 /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = DBA80C890500B9F22A637FC3526C1F33 /* RACStringSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F03EB9DB61DC356DBCFB7A1A57E2BE68 /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = B9100F21CA0D4E47FCF754BAB371F609 /* RACArraySequence.m */; };
+		F056B1BF6DD0CA8F876AA8EB9FD41D3F /* ZIKQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 29BA88C63C3FFB93B343E609BFB36514 /* ZIKQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1F4E65611F5567A86AF797EAC3E225B /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 08F3CE47921C98C7E3C64DADA02E1FD1 /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F3F415BDCAE1690166333A8A258D4E82 /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 465F150AE4860D39F54E78F690CD3588 /* NSObject+RACKVOWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F446A9B5EFC5F145735E55499C63C84C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */; };
+		F4CA468B5A9F8FF2A4DB8B236A8E71BF /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7381D6137E81390705BD1F225F55ED8C /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7BE82F1A42B7BB6E76BF131C5945744 /* UITextView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FFDD270ED91A2E840E585A1C2F75CB /* UITextView+RACSignalSupport.m */; };
+		F7E0022943AC595A7CCD87C665064B73 /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 425DA1B18BCD936BCD045C30033B2060 /* RACSerialDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7E4A95706FF37D165A5C1AB605CAC52 /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 80F8E76076FC9F2A52A8D699305B5574 /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA8F32D61A7CDD423DC31038E0945D7C /* UITableViewCell+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C8E5B0E6B099D2FAC8CA2E85AC0D6BAB /* UITableViewCell+RACSignalSupport.m */; };
+		FAF3834F85CA85CF81C799070D100D9B /* ZIKTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F5696B17FB83D0EEC91FA13AC1DCC99 /* ZIKTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB75139C86866B119A72439090ADED56 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DDBAB553306DD9C134557FA8B17A80 /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB858FB338BE34B7D8B9B30DAEF749D3 /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FFDC4DF7EFC3EB7B20C19CEE4FFA320 /* RACSequence.m */; };
+		FC64CB0A024BDD72D8BCC9EE1D7A7633 /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D5AE802408CB4E2D6331A7EBD0556835 /* RACUnarySequence.m */; };
+		FCA9BAF8CF708718EC503C38708AD0B9 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DA78ED7A84B4444BABBB71B33945E4 /* NSArray+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD64BCBD66378EF10897C480FE7143E3 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 496296157B5A145E2E82456EEDCABC9C /* XCTestCase+Specta.m */; };
+		FD8DD4D5F90C499ACF28ABAB3CF346A7 /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 6806715BC9D98C550266073CCF5A36FD /* RACSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDF72740DBC37AFACFED73ED42282383 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BE3B0D19EAF6A923E75AA5791F6593AF /* Expecta-dummy.m */; };
+		FE58FAEF498BDD915A265A5B36CEEA55 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */; };
+		FF1C2A1C7239535E512486CDEE6AB71C /* ZIKRoot.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B67C15C575D93F1F37E5CDB2B688E64 /* ZIKRoot.m */; };
+		FF6627DB2E5BD34FD3473AB4E217A7A8 /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 2053CD78FFD7A94ECDB6E8E14467A2E5 /* RACReplaySubject.m */; };
+		FF68A09176DB8794E418CD80B8AEE20D /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CE53639CC6731F2B6329A8D56BFB7062 /* NSSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		1FB56A8F48A216603038CA7A269EC5EF /* PBXContainerItemProxy */ = {
+		0B8101B59577FD0FF51309759D84F21B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D3A64ECCCBFFF840589B13BDEC5658CA;
-			remoteInfo = ReactiveCocoa;
-		};
-		25F35F0CF5FC2C66A0B5EB5DCF6D6615 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 88184F740D065EA56B766F2AA3CB2C89;
-			remoteInfo = SocketRocket;
-		};
-		4EFB56BC0035EAEA5E4ADB8FB30EB9D4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D3A64ECCCBFFF840589B13BDEC5658CA;
-			remoteInfo = ReactiveCocoa;
-		};
-		5F7E852D1153D68AAE7F50B47D173CA6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 88184F740D065EA56B766F2AA3CB2C89;
-			remoteInfo = SocketRocket;
-		};
-		9AF2B4F6BAFDC4E6A99EA5E2EAF55AD7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 37E21E3BEC55210F96E0E70DD1D5C67F;
-			remoteInfo = "ZettaKit-ZettaKit";
-		};
-		A9CAA3C37F35BF99A43A339ABC3F8E4B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 88184F740D065EA56B766F2AA3CB2C89;
-			remoteInfo = SocketRocket;
-		};
-		ADEBA8B8691F42EAD97CC6FBA908D599 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E3BBC7436BFB11CEA6FEA7154092CCE5;
-			remoteInfo = ZettaKit;
-		};
-		DE4F913778A48FEBF92C9A97E10CDFC6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D3A64ECCCBFFF840589B13BDEC5658CA;
-			remoteInfo = ReactiveCocoa;
-		};
-		E2C616F35B5E594FDB000398E3710716 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E97A02DD69143CF53448FEACFEE09AEF;
+			remoteGlobalIDString = C656B1062EF5478BD86D177C779AD322;
 			remoteInfo = Specta;
 		};
-		F4CE0B32AA678F963166273E01AE0B47 /* PBXContainerItemProxy */ = {
+		4B5F08533225606C35FE1B0AAD7BB4B6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E3BBC7436BFB11CEA6FEA7154092CCE5;
+			remoteGlobalIDString = EFBF56E35BBB16C86D5BE5D8756EFF7B;
+			remoteInfo = ReactiveCocoa;
+		};
+		627C7FF33AA7A9FF6CCDFD5715C87177 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EFBF56E35BBB16C86D5BE5D8756EFF7B;
+			remoteInfo = ReactiveCocoa;
+		};
+		6617CC05BD5AFCB674D267B7A022F001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ABBB78DB01D7200F26A57501800026B0;
+			remoteInfo = "ZettaKit-ZettaKit";
+		};
+		686D9A35CDF6D2B2162AB96D38861998 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2F501FE84845EAD97B9087DAFCBBEE0E;
+			remoteInfo = Expecta;
+		};
+		89F5D3F36FD54E85BF4B82D382D2E3C9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A1177A0BC321ECAB30C8B49CFFCBDFB;
+			remoteInfo = SocketRocket;
+		};
+		8D1E0362EE9529D78DFB73B60EAC629C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A1177A0BC321ECAB30C8B49CFFCBDFB;
+			remoteInfo = SocketRocket;
+		};
+		9F324B4A9CB1F5429EB2D100B8F2FF4B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 805C72C34E25E78947F6F6DAEE4C43CE;
 			remoteInfo = ZettaKit;
 		};
-		FD96B09BE96174807A2E56EBCC88E0A6 /* PBXContainerItemProxy */ = {
+		A63E88A25D0AA0750ACA87BC70F7295B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5822815B54870852F7739B671476F97;
-			remoteInfo = Expecta;
+			remoteGlobalIDString = EFBF56E35BBB16C86D5BE5D8756EFF7B;
+			remoteInfo = ReactiveCocoa;
+		};
+		D2E4037AAF8057EBD292BE499818A99F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A1177A0BC321ECAB30C8B49CFFCBDFB;
+			remoteInfo = SocketRocket;
+		};
+		ED711062B0B5544BE011F88C82107176 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 805C72C34E25E78947F6F6DAEE4C43CE;
+			remoteInfo = ZettaKit;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0014D3C1086C02FCA5753BE1B850AC72 /* NSURLConnection+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLConnection+RACSupport.h"; path = "ReactiveCocoa/NSURLConnection+RACSupport.h"; sourceTree = "<group>"; };
-		0027C4B0CF621F607D7E2B8661A64AD3 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
-		018381EE57997B3F939BCEA6CC4FAD1F /* RACmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACmetamacros.h; path = ReactiveCocoa/extobjc/RACmetamacros.h; sourceTree = "<group>"; };
-		0191C029BD1ECA582E02CA24DE4A9D95 /* ispdy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ispdy.m; sourceTree = "<group>"; };
-		01AE5DBAA417EF1DD630392B857C33E1 /* RACSignalSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignalSequence.m; path = ReactiveCocoa/RACSignalSequence.m; sourceTree = "<group>"; };
-		01FF14C73FA1CE2B9EDC4A39A0EEECA6 /* ZIKMultiplexStreamEntry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKMultiplexStreamEntry.h; sourceTree = "<group>"; };
-		02F56CE5B19A5F89FA9C32A454BF4C49 /* RACSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriber.h; path = ReactiveCocoa/RACSubscriber.h; sourceTree = "<group>"; };
-		02FB0B910927E303746D94038B1EE898 /* scheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = scheduler.h; sourceTree = "<group>"; };
-		03BAD800091C1652E4E87EFF3E9DC696 /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
-		04D46DBAD30879A86FBEE7ED8EFC736B /* UIAlertView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+RACSignalSupport.m"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		04EF0BDC5A75852B6A4804FE39AB2758 /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
-		07514E922FF2FD77D088C58D3EAF7622 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
-		081E3161312491061B4A24C184D46AC7 /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
-		08AFC5D5C2718231F4C3ED02D2123B7D /* NSUserDefaults+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSUserDefaults+RACSupport.h"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.h"; sourceTree = "<group>"; };
-		092669775C6D16219510B67D37706726 /* UITextView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextView+RACSignalSupport.h"; path = "ReactiveCocoa/UITextView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		093078FB8BCBB56AF0438DA3CBB45122 /* RACEagerSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEagerSequence.m; path = ReactiveCocoa/RACEagerSequence.m; sourceTree = "<group>"; };
-		0A7FD71235C7DDFF3D97CB2A859A3AD7 /* RACSerialDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSerialDisposable.h; path = ReactiveCocoa/RACSerialDisposable.h; sourceTree = "<group>"; };
-		0BA333ED8DF8AC7A61AB648B5C010645 /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
-		0C7D4C0F72EA81B1B55A8B00FE947767 /* NSFileHandle+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileHandle+RACSupport.m"; path = "ReactiveCocoa/NSFileHandle+RACSupport.m"; sourceTree = "<group>"; };
-		0C84D548FC73EA9BB169EE3019C1C0AF /* RACTupleSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTupleSequence.h; path = ReactiveCocoa/RACTupleSequence.h; sourceTree = "<group>"; };
-		0CFCB2F8A59C2DA5ADF2F682B1BEAA09 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CFNetwork.framework; sourceTree = DEVELOPER_DIR; };
-		0CFF91CAF87B0D739672F42DFC1532CC /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
-		0D450F935D5535460CD4F415DB8516D7 /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
-		0D8B40E1B9008EA8D876D4E2FC933EA2 /* RACKVOTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOTrampoline.h; path = ReactiveCocoa/RACKVOTrampoline.h; sourceTree = "<group>"; };
-		0F2E0A8616542DF80071FFE254B3EB9A /* RACValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACValueTransformer.h; path = ReactiveCocoa/RACValueTransformer.h; sourceTree = "<group>"; };
-		104C0F5DE855DF66ACA9C5419F23646E /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
-		108BA2EE35F2E53D146EFA0AB8880F8F /* NSString+RACKeyPathUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACKeyPathUtilities.h"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.h"; sourceTree = "<group>"; };
-		1155C4A11B46AB9BFC5B32CE3C89B294 /* RACUnit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnit.m; path = ReactiveCocoa/RACUnit.m; sourceTree = "<group>"; };
-		115C199FC5D2399E662C60DECE8BECDD /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
-		11E3E46C97AE920E685285051A98DB34 /* Pods-ZettaKit-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ZettaKit-acknowledgements.plist"; sourceTree = "<group>"; };
-		147E3E9145BBADBD45B55AAA3E000BC0 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
-		14D377B47B7C7F6DBF87DC8722DF2895 /* RACTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTuple.h; path = ReactiveCocoa/RACTuple.h; sourceTree = "<group>"; };
-		1500FDD1767362848287A77BAB4ACD64 /* RACStringSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStringSequence.m; path = ReactiveCocoa/RACStringSequence.m; sourceTree = "<group>"; };
-		15D02E4033F4D6EF61F7E71C4C5A6047 /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
-		15EBEFF8684157C7D981950827C477A4 /* RACKVOChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOChannel.m; path = ReactiveCocoa/RACKVOChannel.m; sourceTree = "<group>"; };
-		15FA16F0D5C03728F01CDA5EADC5FCA6 /* NSData+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+RACSupport.m"; path = "ReactiveCocoa/NSData+RACSupport.m"; sourceTree = "<group>"; };
-		1647E4273B7E0BD7C404C2BF6756EF16 /* NSInvocation+RACTypeParsing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+RACTypeParsing.m"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.m"; sourceTree = "<group>"; };
-		19AD852DA6297196F88BE42ECB5D5B77 /* NSURLConnection+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLConnection+RACSupport.m"; path = "ReactiveCocoa/NSURLConnection+RACSupport.m"; sourceTree = "<group>"; };
-		1A30A796A4BA421118BCF4DA13978723 /* RACTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTuple.m; path = ReactiveCocoa/RACTuple.m; sourceTree = "<group>"; };
-		1A3F63CEE7D957475C690D21744C92EF /* RACImmediateScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACImmediateScheduler.h; path = ReactiveCocoa/RACImmediateScheduler.h; sourceTree = "<group>"; };
-		1B1AC55CD4A61F4881AAFEF03A88E0A8 /* libSocketRocket.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSocketRocket.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		1C4A7FE62604FBEB893337F882F60EAD /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
-		201FB40811A25F91BC538292BFA9DFA3 /* RACEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEvent.h; path = ReactiveCocoa/RACEvent.h; sourceTree = "<group>"; };
-		202BC15722571669D200E8ADA64B2BEB /* RACEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEXTRuntimeExtensions.m; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.m; sourceTree = "<group>"; };
-		2058EBEE764BEEA8354D1A4D32C972F1 /* parser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = parser.m; sourceTree = "<group>"; };
-		21003E153499263B2F932EDD9F77F1DF /* UIGestureRecognizer+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIGestureRecognizer+RACSignalSupport.m"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m"; sourceTree = "<group>"; };
-		211FAB023F6DB10974ED4122E5357AF0 /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
-		21712F76C7F7B920E58A35088232C1EC /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
-		2193B187592F9DE28CB3B599F4C99D86 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
-		21E1481F317AA4D3FA9E8B4431E6E873 /* UIButton+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+RACCommandSupport.h"; path = "ReactiveCocoa/UIButton+RACCommandSupport.h"; sourceTree = "<group>"; };
-		21E2FDDD537A7835AB5F4AC1F5085CA2 /* RACSubscriptingAssignmentTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptingAssignmentTrampoline.m; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m; sourceTree = "<group>"; };
-		2383BDAEE579F5C80A2BA3B682D038FE /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
-		23D73C10A5A05E97D81B467C67A1310E /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
-		23F488A9B0F5CE26FC2321AF708C29B2 /* RACQueueScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACQueueScheduler+Subclass.h"; path = "ReactiveCocoa/RACQueueScheduler+Subclass.h"; sourceTree = "<group>"; };
-		25C2836BCC935BD8A46E618D13184C36 /* UITableViewHeaderFooterView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewHeaderFooterView+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		27257204FF7BB2B319F60B68748779C8 /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
-		27A36CEF3E5D04D7B9EDA2B6C0ED5197 /* UIButton+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+RACCommandSupport.m"; path = "ReactiveCocoa/UIButton+RACCommandSupport.m"; sourceTree = "<group>"; };
-		28197293FC0816184F9DD6F5B73F9004 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
-		29DF0EB3518882D15FABD9EE8F48A47E /* SRWebSocket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRWebSocket.h; path = SocketRocket/SRWebSocket.h; sourceTree = "<group>"; };
-		2A56E63A6C327D0B47BF98D555CDC5B1 /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
-		2BEF4896B8618DC0EFF6D6E5EB97E092 /* NSNotificationCenter+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+RACSupport.m"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.m"; sourceTree = "<group>"; };
-		2C0A7E8190DDCE8CD41B61D10A7676B8 /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
-		2D68B7CE019CBAA096DDE45EB2D6A056 /* UIDatePicker+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIDatePicker+RACSignalSupport.m"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.m"; sourceTree = "<group>"; };
-		2D775FFC9C2788090E0FB1EFFC080324 /* RACKVOProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOProxy.h; path = ReactiveCocoa/RACKVOProxy.h; sourceTree = "<group>"; };
-		2D8A3A853C849192781B875A13274078 /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
-		2DB33A1AB7C51F3D80DB728C8F87D7DF /* NSEnumerator+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSEnumerator+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		2E7418D91B25E6D9AA392FE90B771BF6 /* UIControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupport.h"; path = "ReactiveCocoa/UIControl+RACSignalSupport.h"; sourceTree = "<group>"; };
-		2F615E19B20280D1880B90357C80B364 /* UISlider+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISlider+RACSignalSupport.m"; path = "ReactiveCocoa/UISlider+RACSignalSupport.m"; sourceTree = "<group>"; };
-		2FE3702BA7CD7C1EF918F1FFEC37B2E8 /* RACDynamicSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSequence.m; path = ReactiveCocoa/RACDynamicSequence.m; sourceTree = "<group>"; };
-		30C010160F3AFB94CA4DEC12F2842BBC /* NSString+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSupport.m"; path = "ReactiveCocoa/NSString+RACSupport.m"; sourceTree = "<group>"; };
-		31DC802B1F725960B0D821347C18D1E5 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		32093DC7D4B11A56582CC752D65A9B4E /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		33763041BE3BFAE434444AF2CBDF18D6 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		33BB7F6EE2D7770EC191EE930AC170EF /* RACCompoundDisposableProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACCompoundDisposableProvider.d; path = ReactiveCocoa/RACCompoundDisposableProvider.d; sourceTree = "<group>"; };
-		33BE1AFB3E5E4655FB27567CB70D9911 /* ZIKRoot.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKRoot.m; sourceTree = "<group>"; };
-		343F1AD91DE594FB0E7441E12DC037A2 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
-		36A3CB14FC8276F4531C8118B497060B /* libZettaKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libZettaKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		38F23B614E709D461ABF8B5E1D21E831 /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
-		3A72AA5D46AE85EF9B309863E64165F2 /* Pods-ZettaKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ZettaKit-dummy.m"; sourceTree = "<group>"; };
-		3AC3C4882E27A01D5721D5AB3AE3A4A5 /* RACTargetQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTargetQueueScheduler.m; path = ReactiveCocoa/RACTargetQueueScheduler.m; sourceTree = "<group>"; };
-		3B50757FB194775750692B1722CDA7EA /* RACSubscriptionScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptionScheduler.h; path = ReactiveCocoa/RACSubscriptionScheduler.h; sourceTree = "<group>"; };
-		3BEFD09469425B8A59DD281F2D23A3F2 /* RACDelegateProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDelegateProxy.m; path = ReactiveCocoa/RACDelegateProxy.m; sourceTree = "<group>"; };
-		3CB800A46024B1C2237C0FC9AC296F8F /* SocketRocket-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SocketRocket-dummy.m"; sourceTree = "<group>"; };
-		3CC78350520EF41E68B640BC8A5FEFFC /* RACCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCommand.m; path = ReactiveCocoa/RACCommand.m; sourceTree = "<group>"; };
-		3CD337E30EEDD66408D742FA6EE2BDC5 /* RACEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTScope.h; path = ReactiveCocoa/extobjc/RACEXTScope.h; sourceTree = "<group>"; };
-		3E7656605139E2DF7947A1B93712E515 /* ReactiveCocoa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ReactiveCocoa.h; path = ReactiveCocoa/ReactiveCocoa.h; sourceTree = "<group>"; };
-		3F3A21108079A2E1E89C7AF36B8B1DFA /* ZIKUtil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKUtil.m; sourceTree = "<group>"; };
-		3F56CD047BEB7C6A003B63CA4718AE41 /* NSObject+RACSelectorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACSelectorSignal.m"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.m"; sourceTree = "<group>"; };
-		3FF6936CE62992A4B9996A0E32768C1E /* framer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = framer.m; sourceTree = "<group>"; };
-		40269D438003ADFFC4896C29734DED55 /* RACSignal+Operations.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "RACSignal+Operations.m"; path = "ReactiveCocoa/RACSignal+Operations.m"; sourceTree = "<group>"; };
-		4041595FE659F3590E2DD68D1B6DB398 /* RACSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSequence.m; path = ReactiveCocoa/RACSequence.m; sourceTree = "<group>"; };
-		40FE3B185463A321496134062A3DEED8 /* UISegmentedControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISegmentedControl+RACSignalSupport.m"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.m"; sourceTree = "<group>"; };
-		41612113711B99B4D5EDF19455EA0580 /* NSObject+RACKVOWrapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACKVOWrapper.m"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.m"; sourceTree = "<group>"; };
-		41FB60C485E0BB6B9535A63B57598619 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
-		42511B8B3C1E29DB714664F1A8B2DC97 /* libExpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libExpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		4261CD967FB77A20DA53A438C37DF7C1 /* UIControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupport.m"; path = "ReactiveCocoa/UIControl+RACSignalSupport.m"; sourceTree = "<group>"; };
-		4471018357436A1557EE90ED9B1F7378 /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		44AB47B754C797DB20763B4DF661C931 /* RACSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubject.m; path = ReactiveCocoa/RACSubject.m; sourceTree = "<group>"; };
-		45018390477900ABFD4D22979EBCB816 /* libReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactiveCocoa.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		47A8BFEE5942CA0FD0E5E0BA5F323B30 /* RACQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACQueueScheduler.h; path = ReactiveCocoa/RACQueueScheduler.h; sourceTree = "<group>"; };
-		47B8C4F1228CB66BA3181891CBA0DB4E /* UIDatePicker+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIDatePicker+RACSignalSupport.h"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.h"; sourceTree = "<group>"; };
-		47E31E9FFF0ACC7D29F7C49292E390CA /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
-		48F945F3F5C9B2F367CF1D04074E9063 /* RACGroupedSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACGroupedSignal.m; path = ReactiveCocoa/RACGroupedSignal.m; sourceTree = "<group>"; };
-		4AD3305FF4E3C4746C82AA701E2D9F8F /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		4ADEA058D137A5E214779E450F9E09A0 /* Pods-ZettaKit-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ZettaKit-acknowledgements.markdown"; sourceTree = "<group>"; };
-		4BC55603216527453AE4FB44CC0B3B1A /* ZIKStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKStream.h; sourceTree = "<group>"; };
-		4CC318C6BD5F93FB1DDD89B727074DCB /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
-		4D3A94B2E9EC307ADA2AAB831105B61A /* NSDictionary+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		4D47E84989BB66D7CA4330E2F52A50E4 /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
-		4D824F85C9A3F2F486A719978CC0B4E9 /* ZIKQuery.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKQuery.m; sourceTree = "<group>"; };
-		4DD6B609F35559EA18FC4C6302ECF048 /* RACEmptySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySequence.h; path = ReactiveCocoa/RACEmptySequence.h; sourceTree = "<group>"; };
-		4E0D605C9547170F5E5A1A850EA9E8EA /* NSDictionary+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		4E781F612A4CA483CECB9598AFF7256B /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
-		4F4158EBD4E8E18F2AF4568A2617E694 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		4F4DF0C78D7F95F3A8AD05D71BF8AE24 /* RACBlockTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBlockTrampoline.m; path = ReactiveCocoa/RACBlockTrampoline.m; sourceTree = "<group>"; };
-		50CAB6E112050E908BCE5A95DBBAE81A /* Pods-ZettaKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ZettaKit.debug.xcconfig"; sourceTree = "<group>"; };
-		5121C43167B486104EF1B5B4F91769AE /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
-		51B318510EF225CFC16F065802B4375B /* ZIKPubSubBroker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKPubSubBroker.h; sourceTree = "<group>"; };
-		52A23864040D30E50974CD5F0DD11AE5 /* RACScheduler+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Private.h"; path = "ReactiveCocoa/RACScheduler+Private.h"; sourceTree = "<group>"; };
-		52FA142C78437F9A9E4EBB03F89D1B27 /* RACReturnSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReturnSignal.m; path = ReactiveCocoa/RACReturnSignal.m; sourceTree = "<group>"; };
-		539F8DA1A80C4B529B2BE97EF6A21E1C /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
-		53F26C05150855A98E88A602F4DB3725 /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
-		545C1E1CC57B35BBE7AE0F51A535A13E /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
-		546BB867D098E9B9C3019D8541BE2EEC /* RACBacktrace.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBacktrace.m; path = ReactiveCocoa/RACBacktrace.m; sourceTree = "<group>"; };
-		5553608D3E681310854569BC39EA7567 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
-		55ED6F319D93F803132751875DF55547 /* ispdy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ispdy.h; sourceTree = "<group>"; };
-		5613A39E0CC3C230CD3DFE338FBD9D05 /* RACSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSequence.h; path = ReactiveCocoa/RACSequence.h; sourceTree = "<group>"; };
-		56971F82844624B96D2ACDA30390A280 /* SRWebSocket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRWebSocket.m; path = SocketRocket/SRWebSocket.m; sourceTree = "<group>"; };
-		56C1388C883ECC9592080F1F4651B108 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
-		57876C1F28D0C180023DCBB0276C81C0 /* Expecta-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Expecta-Private.xcconfig"; sourceTree = "<group>"; };
-		5892393962A478CC5E04E99FE1A3757D /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
-		58B8E899FA45567F698CB1C4794484C9 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
-		59A69E01AD132247A736B86F90C02B00 /* RACCompoundDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCompoundDisposable.m; path = ReactiveCocoa/RACCompoundDisposable.m; sourceTree = "<group>"; };
-		5A8EE7EC34BC6EE2E2E9989ED0139B9F /* RACBacktrace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBacktrace.h; path = ReactiveCocoa/RACBacktrace.h; sourceTree = "<group>"; };
-		5EBA97F8EE77602656B8F3244AEB15A8 /* ZIKRoot.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKRoot.h; sourceTree = "<group>"; };
-		5FFB1C122FF3CFD89502B26937D763DA /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
-		60638554325FEAC8776DDAE4CCDE5633 /* ZIKTransition.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKTransition.h; sourceTree = "<group>"; };
-		6284FE4E702034EE56E2D9D79CA6FF65 /* ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ReactiveCocoa.xcconfig; sourceTree = "<group>"; };
-		6287254A6C5A7A83041A0DA692E17E9B /* RACDynamicSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSignal.m; path = ReactiveCocoa/RACDynamicSignal.m; sourceTree = "<group>"; };
-		629BE5C5EFD9C1F05EBD0CFC85B49EA7 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
-		63FD5F6DB35C3BD89A4421E07F31516D /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
-		644C22683911EEECE2B3F423D718967F /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
-		6484E48827DACC26C101BB153E4DA868 /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
-		64969607553A419F55D68772C21096C9 /* RACKVOProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOProxy.m; path = ReactiveCocoa/RACKVOProxy.m; sourceTree = "<group>"; };
-		652B1FA7612CE62122306687D3107D75 /* ZIKLogStreamEntry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKLogStreamEntry.m; sourceTree = "<group>"; };
-		65963049F3D276A28B72275D08D742DE /* ZIKDevice.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKDevice.m; sourceTree = "<group>"; };
-		65D3988619FB1D4C6F906990B2633114 /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
-		666A9D1991710F8046A798389B986303 /* RACReturnSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReturnSignal.h; path = ReactiveCocoa/RACReturnSignal.h; sourceTree = "<group>"; };
-		6689654F63605798C353AB2168DBDC85 /* framer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = framer.h; sourceTree = "<group>"; };
-		66E09C91E369C4586C4831F618F831AF /* RACScopedDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScopedDisposable.m; path = ReactiveCocoa/RACScopedDisposable.m; sourceTree = "<group>"; };
-		674EFBE953AD3B06A235EC0B5C0E8D50 /* UIImagePickerController+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImagePickerController+RACSignalSupport.h"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.h"; sourceTree = "<group>"; };
-		6785E4D735DDD2CE69A963A4AF5EE599 /* UIBarButtonItem+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIBarButtonItem+RACCommandSupport.h"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h"; sourceTree = "<group>"; };
-		67CC2BE33D4A7B41784DB071217D83C3 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
-		69B70C7D88057FD710BE665508EA82C2 /* RACEmptySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySequence.m; path = ReactiveCocoa/RACEmptySequence.m; sourceTree = "<group>"; };
-		69BCFE802A9187865C3913B48062E692 /* RACSubscriptingAssignmentTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptingAssignmentTrampoline.h; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h; sourceTree = "<group>"; };
-		69DD4A8A195C14D7B67FC1103624E4B6 /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
-		6BE4174116100A3787EC4636F12B6795 /* RACUnarySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnarySequence.h; path = ReactiveCocoa/RACUnarySequence.h; sourceTree = "<group>"; };
-		6CCB94BDDE3E06BA35E566623D31F24F /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
-		6D0661C7B18B4DC7635DCE7AE6BF2890 /* loop.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = loop.h; sourceTree = "<group>"; };
-		6E0ABD873ADA6AB516CA8CA48E477B1B /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
-		6EB20819E758FF61FC1C313DF7D108D8 /* RACEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTKeyPathCoding.h; path = ReactiveCocoa/extobjc/RACEXTKeyPathCoding.h; sourceTree = "<group>"; };
-		6F457EA3AA515EF706FAE471958452D6 /* RACTargetQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTargetQueueScheduler.h; path = ReactiveCocoa/RACTargetQueueScheduler.h; sourceTree = "<group>"; };
-		6F6B638A47FF34E7345CDC9C613B5BF5 /* ZettaKit.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZettaKit.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		6F77ADCE2A6CB9E500BBC52CE5F68F2C /* NSOrderedSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSOrderedSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		6FC2080F4068B93C0E233FD81F6BB5DC /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
-		7066A8216BB8CE14B85EEFD689CE5F8B /* RACSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubject.h; path = ReactiveCocoa/RACSubject.h; sourceTree = "<group>"; };
-		71D1BE39A7BE68902A951E7C1A15B7DC /* parser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = parser.h; sourceTree = "<group>"; };
-		71DBD20BD7C22C7055FB294B58532346 /* RACSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignal.h; path = ReactiveCocoa/RACSignal.h; sourceTree = "<group>"; };
-		722BA1E5F28F49563D04F5A1DF32CA42 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
-		72C0552B5CD20267E4FC7A385C657EF7 /* ReactiveCocoa-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ReactiveCocoa-Private.xcconfig"; sourceTree = "<group>"; };
-		741EFB39BE7A75F8318655D9633AAD92 /* UIActionSheet+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActionSheet+RACSignalSupport.h"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.h"; sourceTree = "<group>"; };
-		74EB00DD5C542B047701064CA3AC8BDE /* NSObject+RACDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDescription.h"; path = "ReactiveCocoa/NSObject+RACDescription.h"; sourceTree = "<group>"; };
-		751B822306AAB8E017F2D3241CF6AF3E /* UITextView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextView+RACSignalSupport.m"; path = "ReactiveCocoa/UITextView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		7643DDFA6BD4B41C819F0B038A54F9E8 /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
-		764CC59FC8A9C5A716530F6C0633CA36 /* UIRefreshControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+RACCommandSupport.m"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.m"; sourceTree = "<group>"; };
-		766AFBEC903C05FD57DFFD1B16BB5437 /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
-		772170E58BDF4002BDDC78B04E11140F /* RACValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACValueTransformer.m; path = ReactiveCocoa/RACValueTransformer.m; sourceTree = "<group>"; };
-		775477D4D81CB05B257641F615064B46 /* RACBehaviorSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBehaviorSubject.h; path = ReactiveCocoa/RACBehaviorSubject.h; sourceTree = "<group>"; };
-		78344F6C65F3DCF875A9EC8F70750528 /* ZIKSpdyDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKSpdyDelegate.h; sourceTree = "<group>"; };
-		79370742F5DFE2A0E4C8276DD740EE61 /* NSObject+RACDeallocating.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDeallocating.m"; path = "ReactiveCocoa/NSObject+RACDeallocating.m"; sourceTree = "<group>"; };
-		7AA002324460D09BB5D72A80C49FE986 /* RACUnit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnit.h; path = ReactiveCocoa/RACUnit.h; sourceTree = "<group>"; };
-		7AEF653A1037E7A89C1C1CC2732C30A8 /* RACDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDisposable.h; path = ReactiveCocoa/RACDisposable.h; sourceTree = "<group>"; };
-		7BA24E93A8BA894A9E5B1817DF3310B3 /* RACScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScheduler.h; path = ReactiveCocoa/RACScheduler.h; sourceTree = "<group>"; };
-		7EA71D10164D8195F241085537964C92 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
-		7EC8491A58BF2C5E2E76D9B29E3D1A3B /* ZIKSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKSession.h; sourceTree = "<group>"; };
-		7EF167D699D7776368ACCC311AA44E95 /* RACScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScheduler.m; path = ReactiveCocoa/RACScheduler.m; sourceTree = "<group>"; };
-		7FF34EFBC2A3F53A8864324A5EC966D4 /* ZettaKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ZettaKit.xcconfig; sourceTree = "<group>"; };
-		80456D3EBD0B983DC9A61E4B12B06A5A /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
-		81BCE78B3034395FE60BA9029C9BCED6 /* RACSubscriber+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSubscriber+Private.h"; path = "ReactiveCocoa/RACSubscriber+Private.h"; sourceTree = "<group>"; };
-		829D27E4966BA9A9DFC007200AEF9351 /* UISlider+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISlider+RACSignalSupport.h"; path = "ReactiveCocoa/UISlider+RACSignalSupport.h"; sourceTree = "<group>"; };
-		82B63627E1B60335529B0A85337DFBA2 /* RACChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACChannel.h; path = ReactiveCocoa/RACChannel.h; sourceTree = "<group>"; };
-		82E526B3AAC4E22005C261AC77230110 /* ZIKLogStreamEntry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKLogStreamEntry.h; sourceTree = "<group>"; };
-		85E1916DC30855C0CF4C5FD890F34811 /* ZIKStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKStream.m; sourceTree = "<group>"; };
-		85E6FA106E095C348CFBAE1AA3DF9BE2 /* UITableViewCell+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewCell+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.m"; sourceTree = "<group>"; };
-		866A8DF8152642E71A379E860431BF7C /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		86B87C7E3D18D5348EB52D09B39E0BDF /* UIControl+RACSignalSupportPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupportPrivate.h"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.h"; sourceTree = "<group>"; };
-		8A1EB323DA97E986FED958F224E08993 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
-		8A9D628F995FEC5E279B74E90E9733CA /* RACKVOTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOTrampoline.m; path = ReactiveCocoa/RACKVOTrampoline.m; sourceTree = "<group>"; };
-		8AA55823DB3770639916D4F68BCA4028 /* ZIKSession.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKSession.m; sourceTree = "<group>"; };
-		8B96ECB90ACEB9BEEE6A96D1FDD9AD27 /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
-		8C25130F7B870BFFBA45AE7A0CC22D24 /* loop.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = loop.m; sourceTree = "<group>"; };
-		8C4CBB8EC2C46AE742FC5B4F08D2E4E8 /* NSString+RACKeyPathUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACKeyPathUtilities.m"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.m"; sourceTree = "<group>"; };
-		8CFB9F140491EF5233B5B6DF1638D571 /* RACScopedDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScopedDisposable.h; path = ReactiveCocoa/RACScopedDisposable.h; sourceTree = "<group>"; };
-		8E39002BCCF999437DDDD26D78952B93 /* Pods-ZettaKit-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ZettaKit-resources.sh"; sourceTree = "<group>"; };
-		8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		8FBFE427D22743C4C4FBEDF1DFFB8B1C /* NSOrderedSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSOrderedSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		8FC39347B45D5339153AF336C38D9B50 /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
-		8FF5581A75B3140D834063B20311B2BC /* NSObject+RACLifting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACLifting.h"; path = "ReactiveCocoa/NSObject+RACLifting.h"; sourceTree = "<group>"; };
-		9013288D8F73306EBE028303FBD87338 /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Subclass.h"; path = "ReactiveCocoa/RACScheduler+Subclass.h"; sourceTree = "<group>"; };
-		902F5FD98CA6F8F6FF159687D5ECD159 /* ZIKMultiplexStreamEntry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKMultiplexStreamEntry.m; sourceTree = "<group>"; };
-		90B69ABD67C14F190EA7097764B5F7D6 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
-		91392DE38B4FB4739B17385406654308 /* ZettaKit-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ZettaKit-Private.xcconfig"; sourceTree = "<group>"; };
-		91D8A1EC4259D460C1846F2DB88F2C84 /* NSObject+RACPropertySubscribing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACPropertySubscribing.h"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.h"; sourceTree = "<group>"; };
-		929D00BB58123B006BFD678778A36407 /* UIControl+RACSignalSupportPrivate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupportPrivate.m"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.m"; sourceTree = "<group>"; };
-		93029730447E84BE07FEF552E631522D /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
-		93136A340786946A1744EEF21ADB3813 /* RACObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACObjCRuntime.h; path = ReactiveCocoa/RACObjCRuntime.h; sourceTree = "<group>"; };
-		93BD16374160F79422053EFAAA3CC19C /* RACEagerSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEagerSequence.h; path = ReactiveCocoa/RACEagerSequence.h; sourceTree = "<group>"; };
-		93F2B074CCCBC677B8AC5242D459C20C /* SocketRocket-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "SocketRocket-Private.xcconfig"; sourceTree = "<group>"; };
-		942815D7546898BCF8AF15C5DC9625BE /* RACSignal+Operations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSignal+Operations.h"; path = "ReactiveCocoa/RACSignal+Operations.h"; sourceTree = "<group>"; };
-		9531E303E9D2A1C6DAAA81D34EBB14F4 /* UISegmentedControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISegmentedControl+RACSignalSupport.h"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.h"; sourceTree = "<group>"; };
-		95B6CF2D186FAA0D592B5DE28D92C00B /* NSObject+RACDeallocating.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDeallocating.h"; path = "ReactiveCocoa/NSObject+RACDeallocating.h"; sourceTree = "<group>"; };
-		965931BB62C9B2A504512CA6A6208307 /* RACDynamicSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSequence.h; path = ReactiveCocoa/RACDynamicSequence.h; sourceTree = "<group>"; };
-		969330D3DA916F84CE8974997B87B044 /* NSIndexSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSIndexSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		97CE60A6DDA33813333AF0B9EB93A194 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
-		98201CFB2DAC97ABDEFAA86029E94E29 /* common.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
-		9850722D244E021478F2AFC9AFEA941A /* RACSubscriptionScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptionScheduler.m; path = ReactiveCocoa/RACSubscriptionScheduler.m; sourceTree = "<group>"; };
-		98678187192DF65697D69FE4FE6A5559 /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
-		98D45E8B3747E90936E5B2DBC61E1A8B /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
-		9A3F65A8A96CE404922B21DD9E38AAB9 /* UIStepper+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIStepper+RACSignalSupport.m"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.m"; sourceTree = "<group>"; };
-		9A9866A5BC46C75E35E36D2666D8F997 /* RACIndexSetSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACIndexSetSequence.h; path = ReactiveCocoa/RACIndexSetSequence.h; sourceTree = "<group>"; };
-		9AC95017F44C94DFE1C03D89EA732B26 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
-		9BB0AF273B85C0646D1A4B06202F6D10 /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
-		9D1637BFAABEF75B5A08A03A500EC5C6 /* RACErrorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACErrorSignal.m; path = ReactiveCocoa/RACErrorSignal.m; sourceTree = "<group>"; };
-		9D6B5E91193C842C95227E963B247EE3 /* UISwitch+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISwitch+RACSignalSupport.h"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.h"; sourceTree = "<group>"; };
-		9DBE53E0D0A9D6B0BA879F7EAD2C7310 /* RACEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEvent.m; path = ReactiveCocoa/RACEvent.m; sourceTree = "<group>"; };
-		9DBE662463B3987D25CEED40D39FB676 /* RACSignalSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignalSequence.h; path = ReactiveCocoa/RACSignalSequence.h; sourceTree = "<group>"; };
-		9E3C036B04A117673C553EBA1E274209 /* ZIKServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKServer.m; sourceTree = "<group>"; };
-		9FB897D4EDDD20302EFE9CE101F3D7D4 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
-		9FE733D65B027C06DD030AD91BF135F8 /* RACStream+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACStream+Private.h"; path = "ReactiveCocoa/RACStream+Private.h"; sourceTree = "<group>"; };
-		A0F0406D12915CFF853CD338942C206F /* NSString+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		A15C42C144EA0025F7F35F283F4E0E8F /* RACStringSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStringSequence.h; path = ReactiveCocoa/RACStringSequence.h; sourceTree = "<group>"; };
-		A1749AC4C11FA3F64A7D18023E0638F4 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
-		A23DD93044E067DBC1FD549444602E5A /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
-		A2497882A9E82393DC0DCBF65EE2FDCB /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
-		A24DF0C64AACE3F56BA0F5EF133BB532 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		A25F6660B65F52A1F2C80A9BC2A691AB /* RACArraySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACArraySequence.m; path = ReactiveCocoa/RACArraySequence.m; sourceTree = "<group>"; };
-		A3744DA45A5C7438CFFD2FE1721C0916 /* ZIKLink.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKLink.m; sourceTree = "<group>"; };
-		A3BB8E983EB259F68EEF97FA0B7A8BF9 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
-		A44505ADC9A93CAC7F0AD3E2AE384BAA /* NSObject+RACLifting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACLifting.m"; path = "ReactiveCocoa/NSObject+RACLifting.m"; sourceTree = "<group>"; };
-		A4881E3CE72C3AADAE5448C921A461EB /* UICollectionReusableView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UICollectionReusableView+RACSignalSupport.m"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m"; sourceTree = "<group>"; };
-		A4C247E3A3979D1AE480DCC03A895A20 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
-		A4FE3029CCF36904FE8E4599B033DD1A /* RACQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACQueueScheduler.m; path = ReactiveCocoa/RACQueueScheduler.m; sourceTree = "<group>"; };
-		A53FA3E439D67AA7931E6A40CDB8CDE0 /* request.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = request.m; sourceTree = "<group>"; };
-		A69CE1A2EA59A2BD7B92147474A7F434 /* NSObject+RACSelectorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACSelectorSignal.h"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.h"; sourceTree = "<group>"; };
-		A6E08205EDA9CBD3268E27962E943651 /* RACReplaySubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReplaySubject.h; path = ReactiveCocoa/RACReplaySubject.h; sourceTree = "<group>"; };
-		A7822E15A991503A82F5FEE6E582F0BC /* ReactiveCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ReactiveCocoa-dummy.m"; sourceTree = "<group>"; };
-		A92B4282F05BE212F5B7A2153BB23407 /* ZettaKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ZettaKit-prefix.pch"; sourceTree = "<group>"; };
-		A99E8C74ECF9EC410DC49AF4467097BD /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
-		AA7F69B7E5EF12903A4332C83A36E21A /* RACDynamicSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSignal.h; path = ReactiveCocoa/RACDynamicSignal.h; sourceTree = "<group>"; };
-		AB1AAD99D6DC016BEB100A14C50706BF /* RACMulticastConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACMulticastConnection.h; path = ReactiveCocoa/RACMulticastConnection.h; sourceTree = "<group>"; };
-		ACE6B769E901D0C368B7418D4B98292D /* UISwitch+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISwitch+RACSignalSupport.m"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.m"; sourceTree = "<group>"; };
-		AECDA5692B621682F2E7AAB714AC3DE7 /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
-		AFC35025FCE2CC972744BBF5FEF23360 /* RACSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriber.m; path = ReactiveCocoa/RACSubscriber.m; sourceTree = "<group>"; };
-		AFEA1BBC4BAF09959DE049C2AC6ECFF7 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
-		B0DCDF6A21314BDEC414E3BEA2578D00 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
-		B168AC1BB12F4DE7CB999A34B9EE6FAB /* UIBarButtonItem+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIBarButtonItem+RACCommandSupport.m"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m"; sourceTree = "<group>"; };
-		B27B1F5F1945C74B280C4507186F910D /* RACCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCommand.h; path = ReactiveCocoa/RACCommand.h; sourceTree = "<group>"; };
-		B40962D8C0896819D87F62AB061E8D72 /* RACCompoundDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCompoundDisposable.h; path = ReactiveCocoa/RACCompoundDisposable.h; sourceTree = "<group>"; };
-		B570849141B86EF4DBE208657D201336 /* NSFileHandle+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileHandle+RACSupport.h"; path = "ReactiveCocoa/NSFileHandle+RACSupport.h"; sourceTree = "<group>"; };
-		B5CF5963F7A99D286F3FCA0DB7135C58 /* NSObject+RACDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDescription.m"; path = "ReactiveCocoa/NSObject+RACDescription.m"; sourceTree = "<group>"; };
-		B650A7A6BCA23719411AA89674431D23 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		B6B7225FFF59C164E6280E85C6FC7EE2 /* NSIndexSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSIndexSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		B99CFDFB66A3EF78E9CED6935D32E87B /* RACIndexSetSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACIndexSetSequence.m; path = ReactiveCocoa/RACIndexSetSequence.m; sourceTree = "<group>"; };
-		B9B5E84290F765C88A7EE0A2AE61516B /* RACTestScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTestScheduler.h; path = ReactiveCocoa/RACTestScheduler.h; sourceTree = "<group>"; };
+		000F856D7101A8BC6B178670BC643798 /* RACEagerSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEagerSequence.m; path = ReactiveCocoa/RACEagerSequence.m; sourceTree = "<group>"; };
+		0064A5DFABE906B13C10F14A5268E78D /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
+		00D318E89B99D38C5D403C0086512FAB /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
+		01D0FF60BEAF1393227B134181A3B434 /* RACEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTScope.h; path = ReactiveCocoa/extobjc/RACEXTScope.h; sourceTree = "<group>"; };
+		03193F0A865EBC01C80201BF200C51E2 /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
+		0441E0AE32C0F44CE9A33ACF69DD6B3A /* RACBehaviorSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBehaviorSubject.h; path = ReactiveCocoa/RACBehaviorSubject.h; sourceTree = "<group>"; };
+		06E5982576957E4346DB04D83B0F8783 /* RACTargetQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTargetQueueScheduler.m; path = ReactiveCocoa/RACTargetQueueScheduler.m; sourceTree = "<group>"; };
+		06F21B162DD79BC9EED0217C3F40AC5A /* NSData+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+RACSupport.h"; path = "ReactiveCocoa/NSData+RACSupport.h"; sourceTree = "<group>"; };
+		07CE79FD9A24A5AE629B23FDB46167AF /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
+		080B839C81F8D14FF1FC7F76F5105F20 /* Pods-ZettaKit-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ZettaKit-acknowledgements.plist"; sourceTree = "<group>"; };
+		082C0915AB6CDD2D1AAD0DD48BD1A0AF /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
+		08CD6196DA22FBF673CF70E9FE5DB991 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
+		08E93F192D817B152ED152D748CBF14D /* framer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = framer.m; sourceTree = "<group>"; };
+		08F3CE47921C98C7E3C64DADA02E1FD1 /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
+		09DA554BAD2666EEEB3875559C732A3D /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
+		0AF69967B99B1113F1F14D00B282D8FF /* RACSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriber.m; path = ReactiveCocoa/RACSubscriber.m; sourceTree = "<group>"; };
+		0D4F8DF26508CB420029A380B8B02444 /* UISlider+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISlider+RACSignalSupport.m"; path = "ReactiveCocoa/UISlider+RACSignalSupport.m"; sourceTree = "<group>"; };
+		0E41A919C897C4F73FBEF662DE23BAB8 /* ZIKSpdyDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKSpdyDelegate.m; sourceTree = "<group>"; };
+		0F3B77BC3EA9EC34306989CEEA919CBC /* NSUserDefaults+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSUserDefaults+RACSupport.h"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.h"; sourceTree = "<group>"; };
+		0FC0985E7655086F972C557018F0DA42 /* RACDynamicSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSequence.h; path = ReactiveCocoa/RACDynamicSequence.h; sourceTree = "<group>"; };
+		104A9EDF53C855F535C4ECAFDB2AFE40 /* RACSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubject.h; path = ReactiveCocoa/RACSubject.h; sourceTree = "<group>"; };
+		1164F0FC120495823065569EDEF28865 /* RACEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEvent.h; path = ReactiveCocoa/RACEvent.h; sourceTree = "<group>"; };
+		11BD458135FCFC30F9EF63C65CEEF3C1 /* RACBacktrace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBacktrace.h; path = ReactiveCocoa/RACBacktrace.h; sourceTree = "<group>"; };
+		11FD7D57E6869773BA8B6976BDE365CC /* RACCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCommand.m; path = ReactiveCocoa/RACCommand.m; sourceTree = "<group>"; };
+		12623E9C076D6851E80570E62515A38B /* RACKVOTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOTrampoline.m; path = ReactiveCocoa/RACKVOTrampoline.m; sourceTree = "<group>"; };
+		14F250AC55FCD6D4FBC738496A747132 /* UIDatePicker+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIDatePicker+RACSignalSupport.h"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.h"; sourceTree = "<group>"; };
+		1577B7A21955232EB2572EBB20B0D63C /* RACStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStream.m; path = ReactiveCocoa/RACStream.m; sourceTree = "<group>"; };
+		157D07568C7D5456875136D836176D39 /* RACCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCommand.h; path = ReactiveCocoa/RACCommand.h; sourceTree = "<group>"; };
+		15B84CF3D4D844B8D622A71195CCF4DA /* ZIKServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKServer.h; sourceTree = "<group>"; };
+		15E5BA7EC5F92E9A0A10868F417579A1 /* parser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = parser.h; sourceTree = "<group>"; };
+		17EFEDDED7A7C8597D989FAA6D116C0A /* RACDynamicSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSignal.h; path = ReactiveCocoa/RACDynamicSignal.h; sourceTree = "<group>"; };
+		1905B74F63A0AD41B1CAD8A862561A81 /* NSDictionary+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		197774D0AD9720DC6EE0303C68AA39FE /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
+		1B441EB635414EDF074BAEF21B2058BD /* NSObject+RACDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDescription.m"; path = "ReactiveCocoa/NSObject+RACDescription.m"; sourceTree = "<group>"; };
+		1C05DDE8D0DD9249BA9BFB26911B3EC2 /* loop.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = loop.m; sourceTree = "<group>"; };
+		1C209576F7E761D74D71364070C65292 /* UIButton+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+RACCommandSupport.m"; path = "ReactiveCocoa/UIButton+RACCommandSupport.m"; sourceTree = "<group>"; };
+		1C97FF8DF5E082F83910AA7BE2CAB1D5 /* RACArraySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACArraySequence.h; path = ReactiveCocoa/RACArraySequence.h; sourceTree = "<group>"; };
+		1D5EA101D113472F861FC70F08311BAE /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		1F60CB0C182EC5AFC1AC0CBF56BCB21A /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
+		1F8FE90105F74656A451EEF871EE4711 /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
+		2053CD78FFD7A94ECDB6E8E14467A2E5 /* RACReplaySubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReplaySubject.m; path = ReactiveCocoa/RACReplaySubject.m; sourceTree = "<group>"; };
+		2118C5E5E0E5926EBB1A7A4DE809F68A /* ZIKUtil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKUtil.m; sourceTree = "<group>"; };
+		21AD5F2D89A56E7D9D50A91C60983476 /* RACDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDisposable.m; path = ReactiveCocoa/RACDisposable.m; sourceTree = "<group>"; };
+		21BA92377EADEDD7FA95EF7366D46690 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
+		23613F8E6C3F6F16E151C793E6D80285 /* NSInvocation+RACTypeParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+RACTypeParsing.h"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.h"; sourceTree = "<group>"; };
+		23AE5BBF485C910CA22290047D3E51B6 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
+		23C8257ADCC63FF10D8315B65EAB1C30 /* RACStream+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACStream+Private.h"; path = "ReactiveCocoa/RACStream+Private.h"; sourceTree = "<group>"; };
+		244B27FEC7FF1DD9AF0A2F5593A4835D /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
+		249F9873EAC3626E09E6E0D7BA246631 /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
+		24B1817A010990A13217A95AB7ABAD59 /* RACCompoundDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCompoundDisposable.m; path = ReactiveCocoa/RACCompoundDisposable.m; sourceTree = "<group>"; };
+		24D95EF022E9831DEC806BFBFFBF4ED1 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		25F6B15249280120AA30CF1F70DAB036 /* RACReturnSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReturnSignal.h; path = ReactiveCocoa/RACReturnSignal.h; sourceTree = "<group>"; };
+		2730914A537D4010675370C90905A9E0 /* RACTestScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTestScheduler.h; path = ReactiveCocoa/RACTestScheduler.h; sourceTree = "<group>"; };
+		27DE8DE0E8B6637BA0AF16DD87056317 /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
+		29BA88C63C3FFB93B343E609BFB36514 /* ZIKQuery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKQuery.h; sourceTree = "<group>"; };
+		29D437BACC065C49426D20FC1069D176 /* NSObject+RACDeallocating.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDeallocating.m"; path = "ReactiveCocoa/NSObject+RACDeallocating.m"; sourceTree = "<group>"; };
+		2A6F3E9B05DFBFEF1ADC6E414D21600B /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
+		2B432DFCA87CF1FB63A6D5DCF79AF84E /* RACmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACmetamacros.h; path = ReactiveCocoa/extobjc/RACmetamacros.h; sourceTree = "<group>"; };
+		2B46B65BA10DB7C108ADBFA93C71A0B5 /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
+		2BB5F805E6EE3C8F6F9A4BD84396A798 /* common.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		2C085E99658A5F1CEFB72E60107415DF /* UITableViewHeaderFooterView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewHeaderFooterView+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		2C5BBEF39456C0740E171C5A1F4E5ABE /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
+		2C974A4094111CAC8D6AA56AE309A3EC /* UITextView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextView+RACSignalSupport.h"; path = "ReactiveCocoa/UITextView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		2D978991DE367B110C9D609D627C6077 /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
+		2F3586C221621D26A3BB8500E26980E4 /* NSUserDefaults+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+RACSupport.m"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.m"; sourceTree = "<group>"; };
+		31D8D799CE0B2041E093432361D17E72 /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
+		31F08478421B679BA6E4224FB47CAABC /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
+		32009289A420396C11D7461A264B8B09 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		34330769E5701AA9202A35B2BBDFFE51 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
+		35E1E372DA6F5BF7325EA3EAF2D38748 /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
+		374914A0326FB605CFF021BA226097A4 /* ReactiveCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ReactiveCocoa-dummy.m"; sourceTree = "<group>"; };
+		381EC98E8D5A8F00FF27E6A6052ADBB9 /* RACBlockTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBlockTrampoline.h; path = ReactiveCocoa/RACBlockTrampoline.h; sourceTree = "<group>"; };
+		38B2AAFED4294A3C3DECB1A0A5B69904 /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
+		38FAE971B998F0B35182A3F66E41FA1A /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
+		399EFA25E90256DE4C1D6345BBDC959E /* RACObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACObjCRuntime.h; path = ReactiveCocoa/RACObjCRuntime.h; sourceTree = "<group>"; };
+		3A060474D7A11CF8A75C4BABE1F5A6ED /* SocketRocket-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SocketRocket-dummy.m"; sourceTree = "<group>"; };
+		3BE9DB8559FD1A1D949D1001463622D3 /* UIControl+RACSignalSupportPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupportPrivate.h"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.h"; sourceTree = "<group>"; };
+		3C3FDDD4D50E7B52D3730ADD103D1A60 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
+		3CACCA3C7D4A215EB291B39770BC52DB /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
+		3D9B11BD99BCF95BA193809C6D3C65FA /* RACEmptySignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySignal.m; path = ReactiveCocoa/RACEmptySignal.m; sourceTree = "<group>"; };
+		3E7508F0A9C97F84ED08A362C610BD77 /* ispdy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ispdy.m; sourceTree = "<group>"; };
+		3E928B4F0D64608EEBF469AFCF96AD9D /* UITextField+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextField+RACSignalSupport.h"; path = "ReactiveCocoa/UITextField+RACSignalSupport.h"; sourceTree = "<group>"; };
+		3F5696B17FB83D0EEC91FA13AC1DCC99 /* ZIKTransition.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKTransition.h; sourceTree = "<group>"; };
+		425DA1B18BCD936BCD045C30033B2060 /* RACSerialDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSerialDisposable.h; path = ReactiveCocoa/RACSerialDisposable.h; sourceTree = "<group>"; };
+		42751639AEB7DB107D3E464F4F222E89 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		428B84E579C78098D283602A1DA9F6D7 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		42F6556ABDF624E54F294C42FC4849A8 /* UISlider+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISlider+RACSignalSupport.h"; path = "ReactiveCocoa/UISlider+RACSignalSupport.h"; sourceTree = "<group>"; };
+		4311F1F4907F6B5122084AB91187F1FC /* RACScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScheduler.h; path = ReactiveCocoa/RACScheduler.h; sourceTree = "<group>"; };
+		4399297F896080C94A46270683832A2D /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
+		440035A52587B47DC900191DC2BFC430 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
+		446F933EE90F1244D8D8CA265DBAEB44 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
+		45108978875126195B31FE2DFBEBE629 /* ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ReactiveCocoa.xcconfig; sourceTree = "<group>"; };
+		451E130E882DA10D9DEFD312555F059B /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
+		452246F4F6CB6AB7740F5AEF7ADA1527 /* RACValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACValueTransformer.h; path = ReactiveCocoa/RACValueTransformer.h; sourceTree = "<group>"; };
+		45719AACD7A6ED9EEF636B59ECAC2629 /* NSData+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+RACSupport.m"; path = "ReactiveCocoa/NSData+RACSupport.m"; sourceTree = "<group>"; };
+		460945DB57E6AE36593F74CBC5E10972 /* NSObject+RACLifting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACLifting.m"; path = "ReactiveCocoa/NSObject+RACLifting.m"; sourceTree = "<group>"; };
+		465F150AE4860D39F54E78F690CD3588 /* NSObject+RACKVOWrapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACKVOWrapper.h"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.h"; sourceTree = "<group>"; };
+		474D4012450619FE1462FE15FCB301AE /* RACSubscriptionScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptionScheduler.h; path = ReactiveCocoa/RACSubscriptionScheduler.h; sourceTree = "<group>"; };
+		47CE1F61B9188398391D67DF09B0C0C0 /* RACSignalProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACSignalProvider.d; path = ReactiveCocoa/RACSignalProvider.d; sourceTree = "<group>"; };
+		47ED70C198D1C27DB8FA33274F0DFE53 /* Pods-ZettaKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ZettaKit-dummy.m"; sourceTree = "<group>"; };
+		4803A2B67ED54424ADA2CE58907A1261 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
+		489B54233C8143CF4A90AC905FBDE827 /* scheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = scheduler.m; sourceTree = "<group>"; };
+		48B82B750F17D002C4520D18CB7F5371 /* SocketRocket.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SocketRocket.xcconfig; sourceTree = "<group>"; };
+		48E8266023F937C3457AEDD4178FAECC /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
+		496296157B5A145E2E82456EEDCABC9C /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
+		4B55035C92B38113F12159D6855B552E /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		4C1D35FD2393D0DD8805C9D2AE11B97E /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
+		4D56DA445AE22C32F12F90665904C329 /* ZIKPubSubBroker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKPubSubBroker.m; sourceTree = "<group>"; };
+		4DD35D9531E8326FA3C2C171D3194A51 /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
+		4E5D7FCCFEAB0E4BE322D6EDA4EDFD65 /* RACBlockTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBlockTrampoline.m; path = ReactiveCocoa/RACBlockTrampoline.m; sourceTree = "<group>"; };
+		4E740B8E7A504CC5E613EFD01A9F4EBE /* RACBacktrace.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBacktrace.m; path = ReactiveCocoa/RACBacktrace.m; sourceTree = "<group>"; };
+		4E7B3C5CC96F782C2D3FE5DEEB74B7E8 /* NSObject+RACSelectorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACSelectorSignal.h"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.h"; sourceTree = "<group>"; };
+		4F5634300B7CB65BBBC645113ED9A7F6 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
+		4FB301C423E470ABC52402A4D9C0B018 /* NSFileHandle+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileHandle+RACSupport.h"; path = "ReactiveCocoa/NSFileHandle+RACSupport.h"; sourceTree = "<group>"; };
+		4FD3117EE1D83C2433A050FAE363A02B /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
+		501B3F7AA5171D110E467307574B11CE /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
+		503567FA56A67261C464A92973F0D03D /* ZIKStreamEntry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKStreamEntry.m; sourceTree = "<group>"; };
+		5042AA968A0ABDBE3871B7622F78EB26 /* UIStepper+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIStepper+RACSignalSupport.h"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.h"; sourceTree = "<group>"; };
+		5051018961F950EBF8F277B64ABB2C0B /* RACEmptySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySequence.m; path = ReactiveCocoa/RACEmptySequence.m; sourceTree = "<group>"; };
+		51625C5FA086FBCD75EB57ADEF8462DB /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
+		51F4BDC233123AE3A9EA3A038DF8D2A9 /* NSNotificationCenter+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+RACSupport.h"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.h"; sourceTree = "<group>"; };
+		52C1DFBAACDC4D0D29AB1B7A91239C46 /* RACTargetQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTargetQueueScheduler.h; path = ReactiveCocoa/RACTargetQueueScheduler.h; sourceTree = "<group>"; };
+		537B29BAE46B93F5C1FC44A01BC2D413 /* framer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = framer.h; sourceTree = "<group>"; };
+		575E18E6D08A71A94D6B62266BAB5CD3 /* NSString+RACKeyPathUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACKeyPathUtilities.m"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.m"; sourceTree = "<group>"; };
+		582592C4C062755C4FCCFCF63065992A /* ZIKMultiplexStreamEntry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKMultiplexStreamEntry.m; sourceTree = "<group>"; };
+		5839544CA403ECBB8310740DF5C90EDB /* ZIKStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKStream.h; sourceTree = "<group>"; };
+		583D976916D469215A6FADAB0FBDD73B /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
+		584A2A1EE1548D7617C87D56E67EE011 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		59439829E3C4E56FBAE4F00E266E1A37 /* RACEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTRuntimeExtensions.h; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		59F70B8A4A66AFA5FB397B79FC0491C0 /* UIActionSheet+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActionSheet+RACSignalSupport.m"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.m"; sourceTree = "<group>"; };
+		5A2CA17C9DE8F94CC438954C0FDFE08C /* RACKVOProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOProxy.h; path = ReactiveCocoa/RACKVOProxy.h; sourceTree = "<group>"; };
+		5A693EA863B53FF281CA1C475ED8BBD6 /* RACQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACQueueScheduler.h; path = ReactiveCocoa/RACQueueScheduler.h; sourceTree = "<group>"; };
+		5C15EDA1D8F7B024C74EAB84E6A53A6F /* RACEagerSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEagerSequence.h; path = ReactiveCocoa/RACEagerSequence.h; sourceTree = "<group>"; };
+		5C5715548587871DFC3A3B71BCE2CCAD /* RACEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEXTRuntimeExtensions.m; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		5DAB30DEEBE9F3CB895D58BE6C2D5CA2 /* ZIKQueryResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKQueryResponse.m; sourceTree = "<group>"; };
+		5E3E923494CC00A096130838B50D4926 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
+		5E57C81D7CED70EAC5FCF8435D6CADC0 /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
+		5E8898FC5B43DD1F1C4D4CCB86F47FFB /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
+		5EC40602C388ECBA787A709F0BF646D5 /* compressor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = compressor.h; sourceTree = "<group>"; };
+		5EFED9162BA2F199634F6FF686FB2B9F /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
+		5F85C712B1D6545F7FC0D5F7A09B7E70 /* RACTupleSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTupleSequence.h; path = ReactiveCocoa/RACTupleSequence.h; sourceTree = "<group>"; };
+		5FF282FE24CC88B4329AEB0A042963DF /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
+		5FFDC4DF7EFC3EB7B20C19CEE4FFA320 /* RACSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSequence.m; path = ReactiveCocoa/RACSequence.m; sourceTree = "<group>"; };
+		621D4D723DBE7D4218665E0AC1342C51 /* UIGestureRecognizer+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIGestureRecognizer+RACSignalSupport.h"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h"; sourceTree = "<group>"; };
+		629F9220AD47D610FB0EDF12B1360A90 /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
+		62FFBD32F4A55C1B67C8700F14AD271B /* UISwitch+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISwitch+RACSignalSupport.m"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.m"; sourceTree = "<group>"; };
+		63C90E38CD895BD45DA691C1658C0499 /* RACDelegateProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDelegateProxy.h; path = ReactiveCocoa/RACDelegateProxy.h; sourceTree = "<group>"; };
+		63FFDD270ED91A2E840E585A1C2F75CB /* UITextView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextView+RACSignalSupport.m"; path = "ReactiveCocoa/UITextView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		67D9E087FCDD73C160E78A97F13C3118 /* NSURLConnection+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLConnection+RACSupport.h"; path = "ReactiveCocoa/NSURLConnection+RACSupport.h"; sourceTree = "<group>"; };
+		6806715BC9D98C550266073CCF5A36FD /* RACSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriber.h; path = ReactiveCocoa/RACSubscriber.h; sourceTree = "<group>"; };
+		68FE83FABFC8584A26785B699BEC326C /* ZIKLogStreamEntry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKLogStreamEntry.m; sourceTree = "<group>"; };
+		6A582BDE6093D34AD109839CD6A0EFAB /* UIRefreshControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+RACCommandSupport.m"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.m"; sourceTree = "<group>"; };
+		6B2E69941158970F9E10E899F014394A /* RACObjCRuntime.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACObjCRuntime.m; path = ReactiveCocoa/RACObjCRuntime.m; sourceTree = "<group>"; };
+		6B452F53FC4F7777F91C800ABB6DE335 /* RACTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTuple.h; path = ReactiveCocoa/RACTuple.h; sourceTree = "<group>"; };
+		6CDF80664B47D8E9EAA9B0A72C90C372 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		6D521BB6601809129D7B55C9FD759530 /* RACUnit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnit.m; path = ReactiveCocoa/RACUnit.m; sourceTree = "<group>"; };
+		6D5F26C36098801DA4B1D3E84AE8E441 /* RACKVOChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOChannel.h; path = ReactiveCocoa/RACKVOChannel.h; sourceTree = "<group>"; };
+		6DB0504CF54F499FF286E6877F3115F7 /* UIControl+RACSignalSupportPrivate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupportPrivate.m"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.m"; sourceTree = "<group>"; };
+		6F059BE23CB9165E492C5F0D8CF842FB /* NSEnumerator+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSEnumerator+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		7072B2420C871B152E0C0C9CB4226C6D /* RACUnarySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnarySequence.h; path = ReactiveCocoa/RACUnarySequence.h; sourceTree = "<group>"; };
+		710763F27A87396FAF50139B3A244876 /* libPods-ZettaKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ZettaKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7159390A93C56E54C7582B79460869BA /* RACStringSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStringSequence.m; path = ReactiveCocoa/RACStringSequence.m; sourceTree = "<group>"; };
+		724F059E82DB0D20ABEBC23776B78778 /* RACScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScheduler.m; path = ReactiveCocoa/RACScheduler.m; sourceTree = "<group>"; };
+		7265403BB611452813B830384C77018E /* UIControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupport.m"; path = "ReactiveCocoa/UIControl+RACSignalSupport.m"; sourceTree = "<group>"; };
+		73607478EAE5AC97A9F3D29B6A56B6BE /* ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
+		736866F02218EA68B125AE95FC10C3A1 /* RACSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignal.h; path = ReactiveCocoa/RACSignal.h; sourceTree = "<group>"; };
+		7381D6137E81390705BD1F225F55ED8C /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
+		73C2AE7093A36EAEE5F6B1002D8D8E65 /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
+		74FF21B4E1BFB58DEEABA6E5FA717628 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
+		76259B99B9234E4C2F2E8CF21AA70293 /* UISegmentedControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISegmentedControl+RACSignalSupport.h"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.h"; sourceTree = "<group>"; };
+		76B498C82759B692E86E52E1FA42AB05 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		76B5A6511E6248F836C83CEA0678F8D8 /* RACKVOChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOChannel.m; path = ReactiveCocoa/RACKVOChannel.m; sourceTree = "<group>"; };
+		771858D40C429A9E50FE6C273ED9BCA3 /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
+		7807F865B6F9BCA550F3FF9019137099 /* RACKVOProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOProxy.m; path = ReactiveCocoa/RACKVOProxy.m; sourceTree = "<group>"; };
+		793A0F5669E52E6DE5E9953A9D1A4C51 /* ZettaKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ZettaKit-dummy.m"; sourceTree = "<group>"; };
+		7AAFF20402CE303809D9FABBAD5C779C /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
+		7B1344906DCF6EFB4829EBAAEE7ACEE2 /* RACSubscriptingAssignmentTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptingAssignmentTrampoline.h; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h; sourceTree = "<group>"; };
+		7B67C15C575D93F1F37E5CDB2B688E64 /* ZIKRoot.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKRoot.m; sourceTree = "<group>"; };
+		7BCE3CF1AB18B956FCDAE546831DFED9 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
+		7D291EB38672207FFB7F6315E56AE2DE /* RACStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStream.h; path = ReactiveCocoa/RACStream.h; sourceTree = "<group>"; };
+		7DA8C11328E7004806517437231A49AE /* ispdy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ispdy.h; sourceTree = "<group>"; };
+		7DFA37545B55B0300E856938EB73FFC7 /* RACDynamicSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSequence.m; path = ReactiveCocoa/RACDynamicSequence.m; sourceTree = "<group>"; };
+		7F25A9DF41A6B6F8A96D43FE0C734D55 /* RACUnit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnit.h; path = ReactiveCocoa/RACUnit.h; sourceTree = "<group>"; };
+		7F890F72C0602F1B7621CB4BA83BF8F0 /* NSObject+RACKVOWrapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACKVOWrapper.m"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.m"; sourceTree = "<group>"; };
+		807E74E375C9672962E7B791FA604FF2 /* NSDictionary+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		80DB5EEB97CD8E83D901212B91E0F111 /* ZIKStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKStream.m; sourceTree = "<group>"; };
+		80F8E76076FC9F2A52A8D699305B5574 /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
+		814EF461030D50A1EC6A00CA40AE3328 /* RACErrorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACErrorSignal.h; path = ReactiveCocoa/RACErrorSignal.h; sourceTree = "<group>"; };
+		819F476B597E5250D35F6C4E679C248A /* UITextField+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextField+RACSignalSupport.m"; path = "ReactiveCocoa/UITextField+RACSignalSupport.m"; sourceTree = "<group>"; };
+		81CC7B09121CC961047AD9C78F37DD61 /* NSObject+RACPropertySubscribing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACPropertySubscribing.h"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.h"; sourceTree = "<group>"; };
+		837054C4375CF39A28CDD2D63B5782BA /* ZIKLink.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKLink.m; sourceTree = "<group>"; };
+		83997E2AD682AE9A1F41047F2B0EFC47 /* RACQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACQueueScheduler.m; path = ReactiveCocoa/RACQueueScheduler.m; sourceTree = "<group>"; };
+		841B00772D329753B4025722551543FB /* RACMulticastConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACMulticastConnection.h; path = ReactiveCocoa/RACMulticastConnection.h; sourceTree = "<group>"; };
+		85680E6ABD2FF8667738D7D965B648DE /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
+		87446A059E2B640EB4228A281551157B /* RACPassthroughSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACPassthroughSubscriber.h; path = ReactiveCocoa/RACPassthroughSubscriber.h; sourceTree = "<group>"; };
+		87B68F4BCCBBD414A09F0FA3D01AF6F4 /* ZIKRoot.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKRoot.h; sourceTree = "<group>"; };
+		87F7C8BCB22AD58A12B1572315D52A0A /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		8871C1DA358494BCB93C7EF46B001011 /* RACErrorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACErrorSignal.m; path = ReactiveCocoa/RACErrorSignal.m; sourceTree = "<group>"; };
+		8A0585CECF89D799A21C31A5CF61819C /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
+		8A2E2EB23E9C08AB9237C9153C153BD5 /* UISwitch+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISwitch+RACSignalSupport.h"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.h"; sourceTree = "<group>"; };
+		8A5141ABB6A0DD0A189514163370DE5B /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
+		8B36EBF9EC8D2879793B47CBFF2EF1DC /* RACTupleSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTupleSequence.m; path = ReactiveCocoa/RACTupleSequence.m; sourceTree = "<group>"; };
+		8B9DC7FE487BD7419DBC28A08E1CDB4F /* RACReplaySubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReplaySubject.h; path = ReactiveCocoa/RACReplaySubject.h; sourceTree = "<group>"; };
+		8BAF0ECCC13841E4CD4C8AF3D676DFCC /* ZIKSession.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKSession.m; sourceTree = "<group>"; };
+		8D0862DFD1128B1E6C745191A5B7547F /* libZettaKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libZettaKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D37009F319795E9375273A4713949CB /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
+		8E62896D68CA3F0A194330B49E02FE5D /* UIBarButtonItem+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIBarButtonItem+RACCommandSupport.m"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m"; sourceTree = "<group>"; };
+		90488EF47B11B7F603A859F3742766FB /* UIBarButtonItem+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIBarButtonItem+RACCommandSupport.h"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h"; sourceTree = "<group>"; };
+		90592CE8E298086EEA9D8D1CCD214365 /* request.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = request.m; sourceTree = "<group>"; };
+		90F3434FA054544EA030674A851573A7 /* ZIKStreamEntry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKStreamEntry.h; sourceTree = "<group>"; };
+		91327C47AC2D5061AC2D328304AC9151 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
+		91DDBAB553306DD9C134557FA8B17A80 /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
+		9329180DD4BBB481648E2F4FFDE51D81 /* RACEmptySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySequence.h; path = ReactiveCocoa/RACEmptySequence.h; sourceTree = "<group>"; };
+		94E72A5AC84C6C7261171D59904427D1 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CFNetwork.framework; sourceTree = DEVELOPER_DIR; };
+		94F844683B588ECDCCAA89CEC01236E8 /* NSFileHandle+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileHandle+RACSupport.m"; path = "ReactiveCocoa/NSFileHandle+RACSupport.m"; sourceTree = "<group>"; };
+		9510AD3BA0C99858102DD0BA82B890D8 /* RACEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTKeyPathCoding.h; path = ReactiveCocoa/extobjc/RACEXTKeyPathCoding.h; sourceTree = "<group>"; };
+		95B78E7EFAC5AA14CB23E9449EDB6D71 /* compressor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = compressor.m; sourceTree = "<group>"; };
+		95E262ADE94CCA799941A74055041B23 /* ZIKTransition.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKTransition.m; sourceTree = "<group>"; };
+		9713019DD4155A06917612BBB9819D0B /* RACSubscriptingAssignmentTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptingAssignmentTrampoline.m; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m; sourceTree = "<group>"; };
+		974A64EFD437923F338C35D754EF4F14 /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
+		98A235811D5FE526242C4589C777B925 /* Pods-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-frameworks.sh"; sourceTree = "<group>"; };
+		9A27A1D35EFB8CAC34829886314503F4 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
+		9A56037B984AFB4991EEF77C5FE65301 /* UIControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupport.h"; path = "ReactiveCocoa/UIControl+RACSignalSupport.h"; sourceTree = "<group>"; };
+		9C12AB40C0C3AE2A1ED9074978957237 /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
+		9CD1A380B7532B860A6C0128C7887B36 /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
+		9D783B3F6E90DBF51FE96E0D36EB7FEF /* RACEmptySignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySignal.h; path = ReactiveCocoa/RACEmptySignal.h; sourceTree = "<group>"; };
+		9E4B3F96872494CD3F5BD32B2A635F07 /* ZIKLogStreamEntry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKLogStreamEntry.h; sourceTree = "<group>"; };
+		9E5D9AF4757F7C84882EBD74C7801A4D /* libReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactiveCocoa.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E6CF1CA72EFBF01AC43ACE22B33C14F /* RACMulticastConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACMulticastConnection.m; path = ReactiveCocoa/RACMulticastConnection.m; sourceTree = "<group>"; };
+		9FB41FF7D92DA5FE1C7F0E9D52669738 /* Pods-ZettaKit-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ZettaKit-acknowledgements.markdown"; sourceTree = "<group>"; };
+		A143A972676B0E346EE156FD625C4276 /* NSIndexSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSIndexSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		A3E8D006D5A26EF45A3BF7B3823DF667 /* Pods-ZettaKit-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ZettaKit-frameworks.sh"; sourceTree = "<group>"; };
+		A3FAFEC5430D762DDDD81D87E36ECF89 /* ZIKPubSubBroker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKPubSubBroker.h; sourceTree = "<group>"; };
+		A4E53D0271C74B39CBC63B4B42151879 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
+		A537C926D40E7E6F1CBD456E362BDCA6 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
+		A7829E600BBB4A5BA5883A828B9BBBF3 /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
+		A828718E304242EA2A84DA1F88812529 /* ZIKQueryResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKQueryResponse.h; sourceTree = "<group>"; };
+		A85C90F4299B095EBE7AC5152BA02CAA /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
+		A91C258A43D5ADFF9475D12895F61411 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		A9223D9DAAFC739BAF84DCA384433E3B /* loop.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = loop.h; sourceTree = "<group>"; };
+		A9FDD0D041D126568C997F923FEA26F6 /* RACBehaviorSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBehaviorSubject.m; path = ReactiveCocoa/RACBehaviorSubject.m; sourceTree = "<group>"; };
+		AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		AAA71D1183F9825A15F96A30A5565DCE /* RACImmediateScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACImmediateScheduler.m; path = ReactiveCocoa/RACImmediateScheduler.m; sourceTree = "<group>"; };
+		AB7957E12585177C35D695172EF7ADEE /* RACScheduler+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Private.h"; path = "ReactiveCocoa/RACScheduler+Private.h"; sourceTree = "<group>"; };
+		AC0285802CDE6C920B3F48A3F31E1A59 /* UICollectionReusableView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UICollectionReusableView+RACSignalSupport.h"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		AC59CA58F43E0327E7D352F6665E4E00 /* RACCompoundDisposableProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACCompoundDisposableProvider.d; path = ReactiveCocoa/RACCompoundDisposableProvider.d; sourceTree = "<group>"; };
+		AF685F09A7816D23974C4C4CE728EB4C /* NSObject+RACPropertySubscribing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACPropertySubscribing.m"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.m"; sourceTree = "<group>"; };
+		B06C9DB1C4CBEDD9663F665AFD3E0335 /* Pods-ZettaKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ZettaKit.debug.xcconfig"; sourceTree = "<group>"; };
+		B0CE3A030FB80A882D8B46543CF5655E /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
+		B27E36761CD140C7DC3B21DED464A3CF /* NSObject+RACLifting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACLifting.h"; path = "ReactiveCocoa/NSObject+RACLifting.h"; sourceTree = "<group>"; };
+		B29209402CC5FAFCD53FBC0B40BDC3FF /* NSString+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		B2CEBD589001912EA1B56EBB19A47074 /* RACMulticastConnection+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACMulticastConnection+Private.h"; path = "ReactiveCocoa/RACMulticastConnection+Private.h"; sourceTree = "<group>"; };
+		B47DF783A0B3BF4CF5E21E48D635B563 /* NSURLConnection+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLConnection+RACSupport.m"; path = "ReactiveCocoa/NSURLConnection+RACSupport.m"; sourceTree = "<group>"; };
+		B4F1F165027F1342BCB947165A752CC9 /* UIButton+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+RACCommandSupport.h"; path = "ReactiveCocoa/UIButton+RACCommandSupport.h"; sourceTree = "<group>"; };
+		B5714F791BD7855787CD63418474CF0D /* RACGroupedSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACGroupedSignal.m; path = ReactiveCocoa/RACGroupedSignal.m; sourceTree = "<group>"; };
+		B5BBFB976DB961B4EBC3D4CFC38C8953 /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
+		B5F1B078832036E8314B365385207243 /* NSString+RACKeyPathUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACKeyPathUtilities.h"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.h"; sourceTree = "<group>"; };
+		B60BA7C5006EE0F1EF3558CEE92526AB /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
+		B73C8F282C3073E55887901D2522015F /* RACIndexSetSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACIndexSetSequence.h; path = ReactiveCocoa/RACIndexSetSequence.h; sourceTree = "<group>"; };
+		B7AFF5A1E81FD338B8434B90A6FB86AB /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
+		B8EEF3578F570DFB16E2C0FD25D44FE5 /* ZettaKit.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZettaKit.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9100F21CA0D4E47FCF754BAB371F609 /* RACArraySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACArraySequence.m; path = ReactiveCocoa/RACArraySequence.m; sourceTree = "<group>"; };
+		B969DFDF184326B64EC3307A748DC45D /* ZIKSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKSession.h; sourceTree = "<group>"; };
+		B9AB7070685988A22D4F17677BDDCB19 /* ZIKServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKServer.m; sourceTree = "<group>"; };
+		BA38B6970BF21C123385A2564938F23B /* NSNotificationCenter+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+RACSupport.m"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.m"; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BB54A9BD1067A9FBF329D95FB5C0E2F7 /* RACReplaySubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReplaySubject.m; path = ReactiveCocoa/RACReplaySubject.m; sourceTree = "<group>"; };
-		BB96A5B5259F7CD5B16D87D43D0FD9A8 /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
-		BBABF04D8BD625E55C45D08668540043 /* ZIKStreamEntry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKStreamEntry.h; sourceTree = "<group>"; };
-		BBD98081124D8A75CB4059FBC90AD6E3 /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
-		BC955D2828EDD99D6C7332F0E44CDE35 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		BD0B172354987E049BCEAB7360A0AD1A /* NSSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		BDCB5CEF1814EC7E43CB748B6C1D2A2E /* ZIKServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKServer.h; sourceTree = "<group>"; };
-		BF0DCFD973141FFA067FF687D364C77D /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
-		BFCA99B5C0AA2B98264CB07A3110BB66 /* UIGestureRecognizer+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIGestureRecognizer+RACSignalSupport.h"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h"; sourceTree = "<group>"; };
-		C0BAA20725F0829A4BDF98B119FB4D53 /* RACErrorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACErrorSignal.h; path = ReactiveCocoa/RACErrorSignal.h; sourceTree = "<group>"; };
-		C18E3C2B5B05581989FBAEE89CEFFEEF /* RACChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACChannel.m; path = ReactiveCocoa/RACChannel.m; sourceTree = "<group>"; };
-		C1F4289E67A4C35B37FD33E2B7BE7651 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
-		C289C470169EC72DD86E947E58F182B9 /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
-		C2A2948C50676C32CDBDBD3657A0D7EA /* ZettaKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ZettaKit-dummy.m"; sourceTree = "<group>"; };
-		C30AC3FDD2C139ADCA631E07F6E8FE17 /* Specta-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Specta-Private.xcconfig"; sourceTree = "<group>"; };
-		C4A2E0FF371BAA7674764841CE9B6FC3 /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
-		C525C73AA385D16886B341BFA97FE274 /* ZIKQuery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKQuery.h; sourceTree = "<group>"; };
-		C5CE33960B44198C4DDC468605A3ADDC /* libPods-ZettaKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ZettaKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C61741E1194F8E72D51E3A65260818F5 /* UIActionSheet+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActionSheet+RACSignalSupport.m"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.m"; sourceTree = "<group>"; };
-		C8304142657F82BDB22B7ACDE39B7705 /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
-		C8BF96FCAEF5B295961CC7377CDFDE14 /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
-		C94E4E78014DCF2A5ED99F78C3BD69DC /* RACStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStream.h; path = ReactiveCocoa/RACStream.h; sourceTree = "<group>"; };
-		C993BB7AE60C5F33AB04CD700CAC0629 /* RACSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignal.m; path = ReactiveCocoa/RACSignal.m; sourceTree = "<group>"; };
-		CA0B1B8AECCD98A5DA0C29594AFEAF15 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		CA4E32DFF53737F96B4EB48C07C099E1 /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
-		CACD8F5BA506CEE1FED45B9C706E62CF /* ZIKLink.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKLink.h; sourceTree = "<group>"; };
-		CB0BA5ACD913C087B8677657EA94569E /* ZIKTransition.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKTransition.m; sourceTree = "<group>"; };
-		CB51EBDAB2BA5E4AC46C870684FD6181 /* RACPassthroughSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACPassthroughSubscriber.h; path = ReactiveCocoa/RACPassthroughSubscriber.h; sourceTree = "<group>"; };
-		CD0C2EBA1F2CA0583C663B9A533E41EF /* RACDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDisposable.m; path = ReactiveCocoa/RACDisposable.m; sourceTree = "<group>"; };
-		CD275CF459A5ADA1EE193B6FACF58D60 /* UICollectionReusableView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UICollectionReusableView+RACSignalSupport.h"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		CE4E8E2AA00AF5EC79748FAD200C21A1 /* UIAlertView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+RACSignalSupport.h"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		CF2DE738F1C28C1D76CCB6C87F9FD17B /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
-		CF52CFD50AECD20F75BCAB84BF6898EB /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
-		CF9BAEC6203B0F46BCD1E3A74F4F14DD /* RACSignalProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACSignalProvider.d; path = ReactiveCocoa/RACSignalProvider.d; sourceTree = "<group>"; };
-		D04F30589CA7E633520E1BF71902834B /* UITextField+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextField+RACSignalSupport.m"; path = "ReactiveCocoa/UITextField+RACSignalSupport.m"; sourceTree = "<group>"; };
-		D0BBBA920D9AB650E46AE31391311239 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
-		D0F81A33D63E139320DC075C646EC4CD /* RACObjCRuntime.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACObjCRuntime.m; path = ReactiveCocoa/RACObjCRuntime.m; sourceTree = "<group>"; };
-		D1F3CFA42BBD89BCB20C2420D89C1A57 /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
-		D29DFB589146C16E787DA8D99C67457B /* scheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = scheduler.m; sourceTree = "<group>"; };
-		D2BA8B179D4FD25A3BCBAEEB16C676AD /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
-		D2C4C9B2BF3F297FE3E292FC6123A039 /* ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
-		D2CB2CF0F32C1F316D49FB54DEB6AFCC /* UITextField+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextField+RACSignalSupport.h"; path = "ReactiveCocoa/UITextField+RACSignalSupport.h"; sourceTree = "<group>"; };
-		D2E3781B67B21441D53FA33F6A4AA633 /* RACEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTRuntimeExtensions.h; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		D3078A0545D4B0A369AED052E0A1C51F /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
-		D4219300BCDF744DF30B8962281BFAB2 /* NSInvocation+RACTypeParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+RACTypeParsing.h"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.h"; sourceTree = "<group>"; };
-		D4C0894F4912137E58A81C235ABE52F7 /* SocketRocket.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SocketRocket.xcconfig; sourceTree = "<group>"; };
-		D5C37883AC62919434C8C3B761A06751 /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
-		D6D611AACFA11DA2CB730200A1E0F329 /* RACBlockTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBlockTrampoline.h; path = ReactiveCocoa/RACBlockTrampoline.h; sourceTree = "<group>"; };
-		D77B7E5726970936BB409415C276DBEC /* RACSerialDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = ReactiveCocoa/RACSerialDisposable.m; sourceTree = "<group>"; };
-		D96E13F7C73E07FEA48CD5198157A4B8 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
-		DA31B5E0ABBB6BFF37808E92019E42B6 /* NSEnumerator+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSEnumerator+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		DA7469EBB0EE6B9C6EC1CBBFA94B1554 /* NSObject+RACKVOWrapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACKVOWrapper.h"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.h"; sourceTree = "<group>"; };
-		DB58D49D15699D96337407A8A2C35AB4 /* RACEmptySignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySignal.h; path = ReactiveCocoa/RACEmptySignal.h; sourceTree = "<group>"; };
-		DC02B51E08E685F6D84ED2E35F49729A /* NSString+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSupport.h"; path = "ReactiveCocoa/NSString+RACSupport.h"; sourceTree = "<group>"; };
-		DD7F6BD61E294C23BA9A6AE080120867 /* NSSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		DEE96CC83E6023D480F94C8408B016EC /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
-		DEED4633D5172B82272BC373AEC78624 /* ZIKStreamEntry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKStreamEntry.m; sourceTree = "<group>"; };
-		E116A852245F9AE7423AE3CDE7FBCB1E /* NSData+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+RACSupport.h"; path = "ReactiveCocoa/NSData+RACSupport.h"; sourceTree = "<group>"; };
-		E34BDF21903B14C620935FC77698BF4C /* NSNotificationCenter+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+RACSupport.h"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.h"; sourceTree = "<group>"; };
-		E404DFDD176C035583EE3E27C674F4C2 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
-		E46A97013558386BBB9749C6A051D894 /* compressor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = compressor.m; sourceTree = "<group>"; };
-		E48C2BFC97916C067AFA88FCDBA67769 /* UITableViewCell+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewCell+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.h"; sourceTree = "<group>"; };
-		E53AAAA4D493D789FCEA3BD930F01CCE /* RACPassthroughSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACPassthroughSubscriber.m; path = ReactiveCocoa/RACPassthroughSubscriber.m; sourceTree = "<group>"; };
-		E573CCE8C9DB021C3550C9E79F48B117 /* RACTestScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTestScheduler.m; path = ReactiveCocoa/RACTestScheduler.m; sourceTree = "<group>"; };
-		E6E9FE5246285877BBD29130C5B9D494 /* SocketRocket-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SocketRocket-prefix.pch"; sourceTree = "<group>"; };
-		E74AC17C2CF5C0313BB096210B7971E6 /* RACBehaviorSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBehaviorSubject.m; path = ReactiveCocoa/RACBehaviorSubject.m; sourceTree = "<group>"; };
-		E74D0C31F5F73E957FDE559E55E40808 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
-		E7D1507786C3052184A83B252D83B182 /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
-		E841C2408971FF1DED138C45FD761ABC /* compressor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = compressor.h; sourceTree = "<group>"; };
-		E8BFF26288BA535373935740D7ADE254 /* RACKVOChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOChannel.h; path = ReactiveCocoa/RACKVOChannel.h; sourceTree = "<group>"; };
-		E97AD6B9417405A4D6A9DF2773C99A33 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		E9AFFE6627D3125C9855BCBCA525AE0E /* ZIKPubSubBroker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKPubSubBroker.m; sourceTree = "<group>"; };
-		E9B8F197F5B8F6E7ED1F441F5327C051 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
-		E9C694BE73E4F96617FAAF17E40ADE3C /* RACMulticastConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACMulticastConnection.m; path = ReactiveCocoa/RACMulticastConnection.m; sourceTree = "<group>"; };
-		EA15C56084EFF2F27C63DA16BCEDF025 /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
-		EA9D007B04968D2533787298BE4632D5 /* UIStepper+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIStepper+RACSignalSupport.h"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.h"; sourceTree = "<group>"; };
-		EAE2C53407FE51FF483D3BBCC97DB6DB /* RACArraySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACArraySequence.h; path = ReactiveCocoa/RACArraySequence.h; sourceTree = "<group>"; };
-		EAE92CC7B639F6C34CD298AA41549D54 /* RACDelegateProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDelegateProxy.h; path = ReactiveCocoa/RACDelegateProxy.h; sourceTree = "<group>"; };
-		EBB6A2AC8482158DD065C6E623FB57E3 /* ZIKDevice.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKDevice.h; sourceTree = "<group>"; };
-		EC1C002644E52229F4C9680EDF9B78B2 /* Pods-ZettaKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ZettaKit.release.xcconfig"; sourceTree = "<group>"; };
-		EC5D8D51CFD27A8625EFFDB8914EA523 /* UIRefreshControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+RACCommandSupport.h"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.h"; sourceTree = "<group>"; };
-		EC79E67C6584F76B74F385ADE15704A1 /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
-		ECFA49D9EC0EA2C510F999A4F4EA1802 /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
-		EE4AAC9129EC516135D799484C4228A3 /* NSUserDefaults+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+RACSupport.m"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.m"; sourceTree = "<group>"; };
-		EE6CA8DDEA2D1749EF81694FA0D05C7E /* RACImmediateScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACImmediateScheduler.m; path = ReactiveCocoa/RACImmediateScheduler.m; sourceTree = "<group>"; };
-		EF7557877A35947FBF94568558DCFAFA /* RACMulticastConnection+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACMulticastConnection+Private.h"; path = "ReactiveCocoa/RACMulticastConnection+Private.h"; sourceTree = "<group>"; };
-		F1C12C84BECEA822C8E998EDCA34F85C /* UIImagePickerController+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImagePickerController+RACSignalSupport.m"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.m"; sourceTree = "<group>"; };
-		F31D3A998B7205B4E0FFEE99616FE1AA /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
-		F32A618C5D89FA438702FDC36FBA0D75 /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
-		F36D7D16B9DF57C4E4B5185F4FCDE9F5 /* RACUnarySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnarySequence.m; path = ReactiveCocoa/RACUnarySequence.m; sourceTree = "<group>"; };
-		F56B09E67C8713A35F5BF7D9A81009BF /* RACGroupedSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACGroupedSignal.h; path = ReactiveCocoa/RACGroupedSignal.h; sourceTree = "<group>"; };
-		F85A9E533C0C56DAE01D75712C9322B1 /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
-		FA24CA8CDD807FAB5C75C3CBCD471603 /* RACEmptySignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySignal.m; path = ReactiveCocoa/RACEmptySignal.m; sourceTree = "<group>"; };
-		FAB36299CB4895BFB612150AED6E9436 /* UITableViewHeaderFooterView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewHeaderFooterView+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		FAFFC9D358DDD39ECB0745FA2023B282 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
-		FB7076DABFA78042AB6E9389ADAA9398 /* RACStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStream.m; path = ReactiveCocoa/RACStream.m; sourceTree = "<group>"; };
-		FBE7B5E036C81297BF24E9A54E824975 /* ZIKSpdyDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKSpdyDelegate.m; sourceTree = "<group>"; };
-		FC2632271DD7F2D79BFB60873A2AB5AE /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
-		FC5828955767805377F40939B33EDAC2 /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
-		FC63BFBC105AD96C09128656B7BF41F8 /* NSObject+RACPropertySubscribing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACPropertySubscribing.m"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.m"; sourceTree = "<group>"; };
-		FD71550502B7972F6A67439A7DFD00B9 /* RACTupleSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTupleSequence.m; path = ReactiveCocoa/RACTupleSequence.m; sourceTree = "<group>"; };
-		FDE9712AE0D061DE230EDF8D1E75D096 /* NSString+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		FF29AE10C019BD4873E0DC281AFF75A3 /* ZIKUtil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKUtil.h; sourceTree = "<group>"; };
-		FF58201FC056BB7FCDBCB159C14664FE /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		BBA54E8CE2A5CE2CC0876E77600938B9 /* SRWebSocket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRWebSocket.m; path = SocketRocket/SRWebSocket.m; sourceTree = "<group>"; };
+		BBE9D05E4F9814E5F26DE9EEA47626B4 /* ZIKSpdyDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKSpdyDelegate.h; sourceTree = "<group>"; };
+		BBF9A6B773BD0568DD8D50E62D6B86B3 /* RACValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACValueTransformer.m; path = ReactiveCocoa/RACValueTransformer.m; sourceTree = "<group>"; };
+		BC093202904054601561F25DA7534E44 /* parser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = parser.m; sourceTree = "<group>"; };
+		BCDE9C15A3117F912F32E8E2CF695BC4 /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Subclass.h"; path = "ReactiveCocoa/RACScheduler+Subclass.h"; sourceTree = "<group>"; };
+		BD111E8EBE043F3CD4204A51FFE005AA /* RACDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDisposable.h; path = ReactiveCocoa/RACDisposable.h; sourceTree = "<group>"; };
+		BE3B0D19EAF6A923E75AA5791F6593AF /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
+		BEB8BD3218534014ECCEBCB5642CC119 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
+		BF9CC99DB0751C60E65BCB260970D6A0 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
+		C22079DDCCC94EA5C5B5C9DF10ACC751 /* ZIKDevice.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKDevice.h; sourceTree = "<group>"; };
+		C3C2081458CBEC4E0C8CBA4FB124389F /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
+		C3FB06352F57BA378EE5504B0CF015A0 /* NSOrderedSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSOrderedSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		C45AF9724992B8B796B18BFF456E45DB /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
+		C57CA92BD28AAA882016E954BF09B40A /* UIDatePicker+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIDatePicker+RACSignalSupport.m"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.m"; sourceTree = "<group>"; };
+		C586B801A1C62272EEE24D11EF15743F /* NSString+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSupport.m"; path = "ReactiveCocoa/NSString+RACSupport.m"; sourceTree = "<group>"; };
+		C5BB01A6E736EEB18B3787A032A944B9 /* RACImmediateScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACImmediateScheduler.h; path = ReactiveCocoa/RACImmediateScheduler.h; sourceTree = "<group>"; };
+		C5BC04C23BCF94E8959DFDB04A78D5CF /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
+		C6AB7BF63C59F61D644EEA4EE631F35C /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
+		C70DFD84E18AC5029210185A3C7E47B0 /* NSSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		C7207F073F97144F41D3C4EC324DC3DD /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
+		C730C42C7E0A20FBC8D5C14FD1F2A2D6 /* RACEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEvent.m; path = ReactiveCocoa/RACEvent.m; sourceTree = "<group>"; };
+		C74D1B18DA9E5234519F4B2CF6043A48 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
+		C7D7BA73518CF55B05357AE182F56818 /* RACSignal+Operations.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "RACSignal+Operations.m"; path = "ReactiveCocoa/RACSignal+Operations.m"; sourceTree = "<group>"; };
+		C7FCAF3EBC70368E629E896F4764C1F7 /* RACReturnSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReturnSignal.m; path = ReactiveCocoa/RACReturnSignal.m; sourceTree = "<group>"; };
+		C81DB42D73B489E1BF1C967655FE2481 /* UITableViewCell+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewCell+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.h"; sourceTree = "<group>"; };
+		C8E5B0E6B099D2FAC8CA2E85AC0D6BAB /* UITableViewCell+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewCell+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.m"; sourceTree = "<group>"; };
+		C921A16385D1282E73FE8B16409CFF93 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
+		C95BC3D2F89DB47545476BC0D3F87139 /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
+		CB02C0E54D42481A62AD3089B3401E7E /* NSIndexSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSIndexSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		CB637AFECB15359174697DC08B4322A9 /* RACSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubject.m; path = ReactiveCocoa/RACSubject.m; sourceTree = "<group>"; };
+		CC2DEA8F4D7EE3348CEC9E09385CAC55 /* UIImagePickerController+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImagePickerController+RACSignalSupport.h"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.h"; sourceTree = "<group>"; };
+		CC94B7B5A389C054C91523F07DE67543 /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
+		CE53639CC6731F2B6329A8D56BFB7062 /* NSSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		CEE15BB7927F71C5EF0D9944E49C3D15 /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
+		CF2365119D4033CBCE693DE31B43892A /* Pods-ZettaKit-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ZettaKit-resources.sh"; sourceTree = "<group>"; };
+		D04D8CA58EDFE213709224E5F95FF668 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
+		D0FEE08548DBA391864FE3E42D81E8AB /* RACScopedDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScopedDisposable.h; path = ReactiveCocoa/RACScopedDisposable.h; sourceTree = "<group>"; };
+		D215B9F08998FEE6B350456C4A96BBE4 /* Pods-ZettaKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ZettaKit.release.xcconfig"; sourceTree = "<group>"; };
+		D385992879D7D7C6C5607ADF621CFA25 /* RACDynamicSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSignal.m; path = ReactiveCocoa/RACDynamicSignal.m; sourceTree = "<group>"; };
+		D5497F7C0AD1EA4BDA02871EE42B3772 /* RACDelegateProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDelegateProxy.m; path = ReactiveCocoa/RACDelegateProxy.m; sourceTree = "<group>"; };
+		D5AE802408CB4E2D6331A7EBD0556835 /* RACUnarySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnarySequence.m; path = ReactiveCocoa/RACUnarySequence.m; sourceTree = "<group>"; };
+		D7C60040C68FBC58D2E7DF1B23E69C65 /* RACSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignal.m; path = ReactiveCocoa/RACSignal.m; sourceTree = "<group>"; };
+		D7FC17245AD1982B1BD013D6BE7A23A2 /* NSString+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		D910F4A0EDA5C55A84D8370680C81F3D /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
+		D98D0755963DF1A845362000E59B8A12 /* NSOrderedSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSOrderedSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		D9CD82B53AF4C7A89CFE08F1166B036C /* ZettaKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ZettaKit-prefix.pch"; sourceTree = "<group>"; };
+		D9FD2BDE956EE1E1B861F22E71D8DFEE /* ZIKUtil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKUtil.h; sourceTree = "<group>"; };
+		DA297289CB857150CDF7A22C104F02D6 /* scheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = scheduler.h; sourceTree = "<group>"; };
+		DA33AD5038F62B8DD1AB1EF1778F757C /* SocketRocket-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SocketRocket-prefix.pch"; sourceTree = "<group>"; };
+		DA6D71F184E95740920E1C34D7E76253 /* NSString+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSupport.h"; path = "ReactiveCocoa/NSString+RACSupport.h"; sourceTree = "<group>"; };
+		DACB96CFE80FED9F7622FCED70899ACD /* RACSubscriptionScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptionScheduler.m; path = ReactiveCocoa/RACSubscriptionScheduler.m; sourceTree = "<group>"; };
+		DB622FA4D3954B9D4C362A81892A87CB /* SRWebSocket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRWebSocket.h; path = SocketRocket/SRWebSocket.h; sourceTree = "<group>"; };
+		DBA80C890500B9F22A637FC3526C1F33 /* RACStringSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStringSequence.h; path = ReactiveCocoa/RACStringSequence.h; sourceTree = "<group>"; };
+		DC72857955E930399D1DBEBF2586F413 /* UICollectionReusableView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UICollectionReusableView+RACSignalSupport.m"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		DCAAF1157A4C0916378424BC991B201A /* RACSerialDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = ReactiveCocoa/RACSerialDisposable.m; sourceTree = "<group>"; };
+		DCBEDA66EAE2B416C80E2DA212FC4E51 /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
+		DD122D058273E923AC4EEED3FD82EC39 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
+		DD724BBF5981B808BF260B8FB9864231 /* ZIKMultiplexStreamEntry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKMultiplexStreamEntry.h; sourceTree = "<group>"; };
+		DFBFD1EA2F0596148164F4C0A56247FB /* libSocketRocket.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSocketRocket.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E010C8D6AF601EA5598C256C26939290 /* NSEnumerator+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSEnumerator+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		E0113159FCF6ECB927AF346ACD793CF2 /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
+		E05781440EB77042BAF5684942D1CC21 /* libExpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libExpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E08532A1035BC677EC5CEB789B819C57 /* UIImagePickerController+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImagePickerController+RACSignalSupport.m"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.m"; sourceTree = "<group>"; };
+		E1745B36AEA70DA46E82E11A30A5A1AA /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
+		E2DA78ED7A84B4444BABBB71B33945E4 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		E2EAAD5DBE06A90DC1F3840D8D719E8B /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
+		E347C79F678AADEDC3D049EB0731C9E2 /* RACSignalSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignalSequence.h; path = ReactiveCocoa/RACSignalSequence.h; sourceTree = "<group>"; };
+		E62CAC8621BAF233839416A17F5DB8A5 /* RACChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACChannel.m; path = ReactiveCocoa/RACChannel.m; sourceTree = "<group>"; };
+		E64DA99843772788110E16DF50E93BE4 /* UIStepper+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIStepper+RACSignalSupport.m"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.m"; sourceTree = "<group>"; };
+		E7ECB7C85249865798147B9AFCEE268F /* RACSignalSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignalSequence.m; path = ReactiveCocoa/RACSignalSequence.m; sourceTree = "<group>"; };
+		E804BEF49DE6021B2954A1A5B5EEB4B2 /* UIActionSheet+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActionSheet+RACSignalSupport.h"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.h"; sourceTree = "<group>"; };
+		E87E3E3D6785A284165237B586375946 /* ZIKLink.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZIKLink.h; sourceTree = "<group>"; };
+		E891EC269F94FE9E1F4DD7CABA531177 /* UISegmentedControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISegmentedControl+RACSignalSupport.m"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.m"; sourceTree = "<group>"; };
+		E8CDF624776F41717486C9D5AE245F7A /* UIAlertView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+RACSignalSupport.h"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		E90A7CB9AA7BD637450DFD338647C738 /* NSObject+RACDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDescription.h"; path = "ReactiveCocoa/NSObject+RACDescription.h"; sourceTree = "<group>"; };
+		E93F5443A0C67A0886A6B4A4B9DD9D4C /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
+		EA8E021EED935A5BC1072A2C2F1D71DF /* RACSignal+Operations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSignal+Operations.h"; path = "ReactiveCocoa/RACSignal+Operations.h"; sourceTree = "<group>"; };
+		EC112ED3538D9B1022DA0CFCD0AFF004 /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
+		EC2D6A8C0E1E4016677E28DB6E064CFE /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
+		EC891F6742F11F128292B7A48860CAB4 /* ZIKQuery.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKQuery.m; sourceTree = "<group>"; };
+		EE3B50DAF85EAF51CE2D43B130D6ECE3 /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
+		EEBAFFBA3116126B88A2E528C1DA6ACF /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
+		EEED1796FF1FF9C0FF40280379C00BC9 /* UIRefreshControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+RACCommandSupport.h"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.h"; sourceTree = "<group>"; };
+		EEEEB648BD8D739F858FB6CB3861E4C7 /* UIAlertView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+RACSignalSupport.m"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		EF2E91920AC3F02EFF7D63150776BA92 /* RACTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTuple.m; path = ReactiveCocoa/RACTuple.m; sourceTree = "<group>"; };
+		F00FC1BA3B556A2035D50CE2493A93B9 /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
+		F28104D710F12599910B64C3A4461F10 /* RACTestScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTestScheduler.m; path = ReactiveCocoa/RACTestScheduler.m; sourceTree = "<group>"; };
+		F2DAF20CA16287BD862139E0D7743366 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
+		F3AD4536DE30D8EA87417415F662E8AC /* NSInvocation+RACTypeParsing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+RACTypeParsing.m"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.m"; sourceTree = "<group>"; };
+		F3E111D4C089C0A31503E716B65AA779 /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
+		F41771A261A6A0500C7457CD20437474 /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
+		F45459ED42E2368FF604F6EDFE0DC4BC /* NSObject+RACDeallocating.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDeallocating.h"; path = "ReactiveCocoa/NSObject+RACDeallocating.h"; sourceTree = "<group>"; };
+		F4903BBCBAB13528A4A33BDA971FBDD2 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		F4CA3F42064F3B1D70243E0FB95B971A /* RACSubscriber+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSubscriber+Private.h"; path = "ReactiveCocoa/RACSubscriber+Private.h"; sourceTree = "<group>"; };
+		F4D5E05A7D460BD2A65B28AE99BA1548 /* RACQueueScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACQueueScheduler+Subclass.h"; path = "ReactiveCocoa/RACQueueScheduler+Subclass.h"; sourceTree = "<group>"; };
+		F50671E063EFF82A71D6980CF8CC780F /* RACGroupedSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACGroupedSignal.h; path = ReactiveCocoa/RACGroupedSignal.h; sourceTree = "<group>"; };
+		F50DEA32B696B39BFDC9D19F8BA3D6D9 /* UITableViewHeaderFooterView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewHeaderFooterView+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		F5EFD47E28DABDF59B64F97718E9F69E /* RACIndexSetSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACIndexSetSequence.m; path = ReactiveCocoa/RACIndexSetSequence.m; sourceTree = "<group>"; };
+		F707E0E883A4C7537200AAD0D1C70533 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
+		F733B8A74D4C6543D511798962A5F09D /* ZIKDevice.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZIKDevice.m; sourceTree = "<group>"; };
+		F74B076165239E6B1C2A4B47523C4E99 /* NSObject+RACSelectorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACSelectorSignal.m"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.m"; sourceTree = "<group>"; };
+		F77F8C85983D53E4908475A4607D3634 /* ZettaKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ZettaKit.xcconfig; sourceTree = "<group>"; };
+		F7AFDE4EF1DB9F469D6328E574A3DA71 /* RACCompoundDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCompoundDisposable.h; path = ReactiveCocoa/RACCompoundDisposable.h; sourceTree = "<group>"; };
+		F7C9CE303847B48B98712D44FA8CA097 /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
+		F7E2504F66F29BA0C91B7EB79EDDF056 /* ReactiveCocoa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ReactiveCocoa.h; path = ReactiveCocoa/ReactiveCocoa.h; sourceTree = "<group>"; };
+		F95948394EDCC4FDBCD734B8878D4125 /* RACSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSequence.h; path = ReactiveCocoa/RACSequence.h; sourceTree = "<group>"; };
+		FA4A7BB2D43ACEBC39C6CFFAD1E9763C /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FCBBEF829D436ED24146C3AB1FEC7F08 /* RACPassthroughSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACPassthroughSubscriber.m; path = ReactiveCocoa/RACPassthroughSubscriber.m; sourceTree = "<group>"; };
+		FD1C69C1991C3CF4E814739A96FC8286 /* RACKVOTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOTrampoline.h; path = ReactiveCocoa/RACKVOTrampoline.h; sourceTree = "<group>"; };
+		FE90FFC1AF01086A63A326DB289CBE9E /* RACScopedDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScopedDisposable.m; path = ReactiveCocoa/RACScopedDisposable.m; sourceTree = "<group>"; };
+		FEA8575E86EB20883AF962870025D142 /* RACChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACChannel.h; path = ReactiveCocoa/RACChannel.h; sourceTree = "<group>"; };
+		FF786D8F7275F32CBABED40CC560AB48 /* UIGestureRecognizer+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIGestureRecognizer+RACSignalSupport.m"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		0D544177BFA6C087CB0CCA48DDE9F123 /* Frameworks */ = {
+		199EF76AC47B3EE9FA80BE53835AB7B1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				837370EF86F1DBBDC12231AB837BC0B6 /* Foundation.framework in Frameworks */,
+				66081D3480D1FA028C4DE2344BF616D4 /* Foundation.framework in Frameworks */,
+				69363A59A4E2FF95D6A62AA88641A20A /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0E532F182B9114AC5864CD2202E1E9DB /* Frameworks */ = {
+		25B17FCFE08AD449B6273F0366106509 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C4C1D1177A9EA78ED5981B5038AE3776 /* Foundation.framework in Frameworks */,
+				6FE4A3073961CA57551263A55E1E798D /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B1E52E7EE4773E0C9FBE31F8647058F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ADF4A57DFB19E393DA00857274112312 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5DB5F0F1F5EA0B8C3101B00DA5907C4C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E537FAE29464DAB3AD1B5D1AF9856439 /* CFNetwork.framework in Frameworks */,
+				F446A9B5EFC5F145735E55499C63C84C /* Foundation.framework in Frameworks */,
+				203C16487FC510B4F643BB017D6F96DA /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9E35AAAA17A9D5CD13555078071EE703 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FE58FAEF498BDD915A265A5B36CEEA55 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B262DFE933C2BC27DE0A53736F999E48 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		42E77651B1258265D9FA78D4F4E152DC /* Frameworks */ = {
+		C7EE037FE5E9D694C0445DD25F45E536 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C5CAC6A2E7158B16713AB4BEBE67A00A /* Foundation.framework in Frameworks */,
-				A98896839A96771C7A49F120AD8A7A96 /* XCTest.framework in Frameworks */,
+				D46E5EABF91B6084F9BB9BA5C89A85E7 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		46F5FA686EAAFFEC5C030B9245657E2B /* Frameworks */ = {
+		D879F4F5EA27F2035545E241CF58A40C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E673B77A321347A73EDBA944EEFE9504 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		667C097AF62529A4EE39210679D0B102 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3EFB7F7818D70DA2B9C871CBE124A3D3 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7D4AC4E217BE8C3D0DE429BB00CB87B2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6892D3C35CD328D4E4EA7059F91B6C81 /* Foundation.framework in Frameworks */,
-				1A7DF66AB5C1BE27A1BDE4BB81FB075B /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BD5EB922B6B09583F86D2093E1ABD10A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				77C1632196F30995F9AECABE077A90D2 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FDF48C0355267306FF24C9CE20B786F2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C3E0BA74990CE99E1804ADBA446445D9 /* CFNetwork.framework in Frameworks */,
-				2F4D345CFE47E8B2D68353120FDAC0E0 /* Foundation.framework in Frameworks */,
-				248333354DA5431D8854806A136DB102 /* Security.framework in Frameworks */,
+				7068DAE4C1AD8CA3551012962F827178 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0A7EFBB8539671F6B0BF1543A7F1E6DF /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				0CFCB2F8A59C2DA5ADF2F682B1BEAA09 /* CFNetwork.framework */,
-				8F73688BF72321BA759696AA68D2D02A /* Foundation.framework */,
-				CA0B1B8AECCD98A5DA0C29594AFEAF15 /* Security.framework */,
-				31DC802B1F725960B0D821347C18D1E5 /* XCTest.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
 		0A91B73A2D74B7FDA8724584C38C3B5D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				449231AD7A7522CAF0E5AA9DF08938C2 /* Expecta */,
-				F03E994872A009065B022476221A4230 /* ReactiveCocoa */,
-				8814A0AD0C11DE7AEC4C587C817E4826 /* SocketRocket */,
-				ED1C3DB259C65EFF41C79684850E614D /* Specta */,
+				C6D08D37B5DD5FBA33C3B7AB6CFE949C /* Expecta */,
+				651733BA43AB4A82DC08C36C40BD9FB8 /* ReactiveCocoa */,
+				C955D3916E6391B3F184350890C064AB /* SocketRocket */,
+				AAA375ABFA2B1B89C94870DBDBF0EFDA /* Specta */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		0E49D847E21E5AC6C81050D0864B4486 /* include */ = {
+		0ABE1E4659A526D99789A614791F2A30 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				55ED6F319D93F803132751875DF55547 /* ispdy.h */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		14B8B9B15ECBE87983FF987239AB2D7B /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				0A7EFBB8539671F6B0BF1543A7F1E6DF /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		2378C33D018E20044A36D69501782721 /* Pods-Tests */ = {
-			isa = PBXGroup;
-			children = (
-				33763041BE3BFAE434444AF2CBDF18D6 /* Pods-Tests-acknowledgements.markdown */,
-				4471018357436A1557EE90ED9B1F7378 /* Pods-Tests-acknowledgements.plist */,
-				C289C470169EC72DD86E947E58F182B9 /* Pods-Tests-dummy.m */,
-				2D8A3A853C849192781B875A13274078 /* Pods-Tests-resources.sh */,
-				B650A7A6BCA23719411AA89674431D23 /* Pods-Tests.debug.xcconfig */,
-				E74D0C31F5F73E957FDE559E55E40808 /* Pods-Tests.release.xcconfig */,
-			);
-			name = "Pods-Tests";
-			path = "Target Support Files/Pods-Tests";
-			sourceTree = "<group>";
-		};
-		449231AD7A7522CAF0E5AA9DF08938C2 /* Expecta */ = {
-			isa = PBXGroup;
-			children = (
-				0CFF91CAF87B0D739672F42DFC1532CC /* EXPBlockDefinedMatcher.h */,
-				15D02E4033F4D6EF61F7E71C4C5A6047 /* EXPBlockDefinedMatcher.m */,
-				D96E13F7C73E07FEA48CD5198157A4B8 /* EXPDefines.h */,
-				47E31E9FFF0ACC7D29F7C49292E390CA /* EXPDoubleTuple.h */,
-				B0DCDF6A21314BDEC414E3BEA2578D00 /* EXPDoubleTuple.m */,
-				0027C4B0CF621F607D7E2B8661A64AD3 /* EXPExpect.h */,
-				04EF0BDC5A75852B6A4804FE39AB2758 /* EXPExpect.m */,
-				D5C37883AC62919434C8C3B761A06751 /* EXPFloatTuple.h */,
-				56C1388C883ECC9592080F1F4651B108 /* EXPFloatTuple.m */,
-				80456D3EBD0B983DC9A61E4B12B06A5A /* EXPMatcher.h */,
-				8FC39347B45D5339153AF336C38D9B50 /* EXPMatcherHelpers.h */,
-				53F26C05150855A98E88A602F4DB3725 /* EXPMatcherHelpers.m */,
-				E9B8F197F5B8F6E7ED1F441F5327C051 /* EXPMatchers.h */,
-				38F23B614E709D461ABF8B5E1D21E831 /* EXPMatchers+beCloseTo.h */,
-				A1749AC4C11FA3F64A7D18023E0638F4 /* EXPMatchers+beCloseTo.m */,
-				211FAB023F6DB10974ED4122E5357AF0 /* EXPMatchers+beFalsy.h */,
-				BBD98081124D8A75CB4059FBC90AD6E3 /* EXPMatchers+beFalsy.m */,
-				F31D3A998B7205B4E0FFEE99616FE1AA /* EXPMatchers+beGreaterThan.h */,
-				58B8E899FA45567F698CB1C4794484C9 /* EXPMatchers+beGreaterThan.m */,
-				ECFA49D9EC0EA2C510F999A4F4EA1802 /* EXPMatchers+beGreaterThanOrEqualTo.h */,
-				28197293FC0816184F9DD6F5B73F9004 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
-				2C0A7E8190DDCE8CD41B61D10A7676B8 /* EXPMatchers+beIdenticalTo.h */,
-				8A1EB323DA97E986FED958F224E08993 /* EXPMatchers+beIdenticalTo.m */,
-				104C0F5DE855DF66ACA9C5419F23646E /* EXPMatchers+beInTheRangeOf.h */,
-				9BB0AF273B85C0646D1A4B06202F6D10 /* EXPMatchers+beInTheRangeOf.m */,
-				9AC95017F44C94DFE1C03D89EA732B26 /* EXPMatchers+beInstanceOf.h */,
-				63FD5F6DB35C3BD89A4421E07F31516D /* EXPMatchers+beInstanceOf.m */,
-				AECDA5692B621682F2E7AAB714AC3DE7 /* EXPMatchers+beKindOf.h */,
-				A23DD93044E067DBC1FD549444602E5A /* EXPMatchers+beKindOf.m */,
-				C1F4289E67A4C35B37FD33E2B7BE7651 /* EXPMatchers+beLessThan.h */,
-				98678187192DF65697D69FE4FE6A5559 /* EXPMatchers+beLessThan.m */,
-				0D450F935D5535460CD4F415DB8516D7 /* EXPMatchers+beLessThanOrEqualTo.h */,
-				6484E48827DACC26C101BB153E4DA868 /* EXPMatchers+beLessThanOrEqualTo.m */,
-				A99E8C74ECF9EC410DC49AF4467097BD /* EXPMatchers+beNil.h */,
-				23D73C10A5A05E97D81B467C67A1310E /* EXPMatchers+beNil.m */,
-				545C1E1CC57B35BBE7AE0F51A535A13E /* EXPMatchers+beSubclassOf.h */,
-				6E0ABD873ADA6AB516CA8CA48E477B1B /* EXPMatchers+beSubclassOf.m */,
-				69DD4A8A195C14D7B67FC1103624E4B6 /* EXPMatchers+beSupersetOf.h */,
-				CF52CFD50AECD20F75BCAB84BF6898EB /* EXPMatchers+beSupersetOf.m */,
-				4E781F612A4CA483CECB9598AFF7256B /* EXPMatchers+beTruthy.h */,
-				97CE60A6DDA33813333AF0B9EB93A194 /* EXPMatchers+beTruthy.m */,
-				AFEA1BBC4BAF09959DE049C2AC6ECFF7 /* EXPMatchers+beginWith.h */,
-				115C199FC5D2399E662C60DECE8BECDD /* EXPMatchers+beginWith.m */,
-				4D47E84989BB66D7CA4330E2F52A50E4 /* EXPMatchers+conformTo.h */,
-				722BA1E5F28F49563D04F5A1DF32CA42 /* EXPMatchers+conformTo.m */,
-				A4C247E3A3979D1AE480DCC03A895A20 /* EXPMatchers+contain.h */,
-				E7D1507786C3052184A83B252D83B182 /* EXPMatchers+contain.m */,
-				1C4A7FE62604FBEB893337F882F60EAD /* EXPMatchers+endWith.h */,
-				D0BBBA920D9AB650E46AE31391311239 /* EXPMatchers+endWith.m */,
-				41FB60C485E0BB6B9535A63B57598619 /* EXPMatchers+equal.h */,
-				0BA333ED8DF8AC7A61AB648B5C010645 /* EXPMatchers+equal.m */,
-				D3078A0545D4B0A369AED052E0A1C51F /* EXPMatchers+haveCountOf.h */,
-				C4A2E0FF371BAA7674764841CE9B6FC3 /* EXPMatchers+haveCountOf.m */,
-				5121C43167B486104EF1B5B4F91769AE /* EXPMatchers+match.h */,
-				27257204FF7BB2B319F60B68748779C8 /* EXPMatchers+match.m */,
-				343F1AD91DE594FB0E7441E12DC037A2 /* EXPMatchers+postNotification.h */,
-				BF0DCFD973141FFA067FF687D364C77D /* EXPMatchers+postNotification.m */,
-				081E3161312491061B4A24C184D46AC7 /* EXPMatchers+raise.h */,
-				F32A618C5D89FA438702FDC36FBA0D75 /* EXPMatchers+raise.m */,
-				67CC2BE33D4A7B41784DB071217D83C3 /* EXPMatchers+raiseWithReason.h */,
-				EA15C56084EFF2F27C63DA16BCEDF025 /* EXPMatchers+raiseWithReason.m */,
-				D1F3CFA42BBD89BCB20C2420D89C1A57 /* EXPMatchers+respondTo.h */,
-				90B69ABD67C14F190EA7097764B5F7D6 /* EXPMatchers+respondTo.m */,
-				A3BB8E983EB259F68EEF97FA0B7A8BF9 /* EXPUnsupportedObject.h */,
-				539F8DA1A80C4B529B2BE97EF6A21E1C /* EXPUnsupportedObject.m */,
-				6CCB94BDDE3E06BA35E566623D31F24F /* Expecta.h */,
-				BB96A5B5259F7CD5B16D87D43D0FD9A8 /* ExpectaObject.h */,
-				5892393962A478CC5E04E99FE1A3757D /* ExpectaObject.m */,
-				F85A9E533C0C56DAE01D75712C9322B1 /* ExpectaSupport.h */,
-				629BE5C5EFD9C1F05EBD0CFC85B49EA7 /* ExpectaSupport.m */,
-				EC79E67C6584F76B74F385ADE15704A1 /* NSObject+Expecta.h */,
-				7EA71D10164D8195F241085537964C92 /* NSValue+Expecta.h */,
-				9FB897D4EDDD20302EFE9CE101F3D7D4 /* NSValue+Expecta.m */,
-				5F9CE621982727A7AB7FDDC613A8741E /* Support Files */,
-			);
-			path = Expecta;
-			sourceTree = "<group>";
-		};
-		5F9CE621982727A7AB7FDDC613A8741E /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				21712F76C7F7B920E58A35088232C1EC /* Expecta.xcconfig */,
-				57876C1F28D0C180023DCBB0276C81C0 /* Expecta-Private.xcconfig */,
-				2A56E63A6C327D0B47BF98D555CDC5B1 /* Expecta-dummy.m */,
-				FC2632271DD7F2D79BFB60873A2AB5AE /* Expecta-prefix.pch */,
+				F3E111D4C089C0A31503E716B65AA779 /* Expecta.xcconfig */,
+				BE3B0D19EAF6A923E75AA5791F6593AF /* Expecta-dummy.m */,
+				31D8D799CE0B2041E093432361D17E72 /* Expecta-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Expecta";
 			sourceTree = "<group>";
 		};
-		6B6737CB05AAA21B0C9D8370E9C57EB0 /* Pod */ = {
+		14B8B9B15ECBE87983FF987239AB2D7B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				AFC2AFEF9289671F36B404AACD0D1BEA /* Classes */,
+				B9D416F8505F251C128105B587A691C8 /* iOS */,
 			);
-			path = Pod;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		6D8C4DBDF80F0DF40C971FB5B109C837 /* Core */ = {
+		158331223CBDA07DF0D10895C856C31F /* ZettaKit */ = {
 			isa = PBXGroup;
 			children = (
-				866A8DF8152642E71A379E860431BF7C /* NSArray+RACSequenceAdditions.h */,
-				FF58201FC056BB7FCDBCB159C14664FE /* NSArray+RACSequenceAdditions.m */,
-				E116A852245F9AE7423AE3CDE7FBCB1E /* NSData+RACSupport.h */,
-				15FA16F0D5C03728F01CDA5EADC5FCA6 /* NSData+RACSupport.m */,
-				4D3A94B2E9EC307ADA2AAB831105B61A /* NSDictionary+RACSequenceAdditions.h */,
-				4E0D605C9547170F5E5A1A850EA9E8EA /* NSDictionary+RACSequenceAdditions.m */,
-				DA31B5E0ABBB6BFF37808E92019E42B6 /* NSEnumerator+RACSequenceAdditions.h */,
-				2DB33A1AB7C51F3D80DB728C8F87D7DF /* NSEnumerator+RACSequenceAdditions.m */,
-				B570849141B86EF4DBE208657D201336 /* NSFileHandle+RACSupport.h */,
-				0C7D4C0F72EA81B1B55A8B00FE947767 /* NSFileHandle+RACSupport.m */,
-				969330D3DA916F84CE8974997B87B044 /* NSIndexSet+RACSequenceAdditions.h */,
-				B6B7225FFF59C164E6280E85C6FC7EE2 /* NSIndexSet+RACSequenceAdditions.m */,
-				D4219300BCDF744DF30B8962281BFAB2 /* NSInvocation+RACTypeParsing.h */,
-				1647E4273B7E0BD7C404C2BF6756EF16 /* NSInvocation+RACTypeParsing.m */,
-				E34BDF21903B14C620935FC77698BF4C /* NSNotificationCenter+RACSupport.h */,
-				2BEF4896B8618DC0EFF6D6E5EB97E092 /* NSNotificationCenter+RACSupport.m */,
-				95B6CF2D186FAA0D592B5DE28D92C00B /* NSObject+RACDeallocating.h */,
-				79370742F5DFE2A0E4C8276DD740EE61 /* NSObject+RACDeallocating.m */,
-				74EB00DD5C542B047701064CA3AC8BDE /* NSObject+RACDescription.h */,
-				B5CF5963F7A99D286F3FCA0DB7135C58 /* NSObject+RACDescription.m */,
-				DA7469EBB0EE6B9C6EC1CBBFA94B1554 /* NSObject+RACKVOWrapper.h */,
-				41612113711B99B4D5EDF19455EA0580 /* NSObject+RACKVOWrapper.m */,
-				8FF5581A75B3140D834063B20311B2BC /* NSObject+RACLifting.h */,
-				A44505ADC9A93CAC7F0AD3E2AE384BAA /* NSObject+RACLifting.m */,
-				91D8A1EC4259D460C1846F2DB88F2C84 /* NSObject+RACPropertySubscribing.h */,
-				FC63BFBC105AD96C09128656B7BF41F8 /* NSObject+RACPropertySubscribing.m */,
-				A69CE1A2EA59A2BD7B92147474A7F434 /* NSObject+RACSelectorSignal.h */,
-				3F56CD047BEB7C6A003B63CA4718AE41 /* NSObject+RACSelectorSignal.m */,
-				6F77ADCE2A6CB9E500BBC52CE5F68F2C /* NSOrderedSet+RACSequenceAdditions.h */,
-				8FBFE427D22743C4C4FBEDF1DFFB8B1C /* NSOrderedSet+RACSequenceAdditions.m */,
-				BD0B172354987E049BCEAB7360A0AD1A /* NSSet+RACSequenceAdditions.h */,
-				DD7F6BD61E294C23BA9A6AE080120867 /* NSSet+RACSequenceAdditions.m */,
-				108BA2EE35F2E53D146EFA0AB8880F8F /* NSString+RACKeyPathUtilities.h */,
-				8C4CBB8EC2C46AE742FC5B4F08D2E4E8 /* NSString+RACKeyPathUtilities.m */,
-				FDE9712AE0D061DE230EDF8D1E75D096 /* NSString+RACSequenceAdditions.h */,
-				A0F0406D12915CFF853CD338942C206F /* NSString+RACSequenceAdditions.m */,
-				DC02B51E08E685F6D84ED2E35F49729A /* NSString+RACSupport.h */,
-				30C010160F3AFB94CA4DEC12F2842BBC /* NSString+RACSupport.m */,
-				0014D3C1086C02FCA5753BE1B850AC72 /* NSURLConnection+RACSupport.h */,
-				19AD852DA6297196F88BE42ECB5D5B77 /* NSURLConnection+RACSupport.m */,
-				08AFC5D5C2718231F4C3ED02D2123B7D /* NSUserDefaults+RACSupport.h */,
-				EE4AAC9129EC516135D799484C4228A3 /* NSUserDefaults+RACSupport.m */,
-				EAE2C53407FE51FF483D3BBCC97DB6DB /* RACArraySequence.h */,
-				A25F6660B65F52A1F2C80A9BC2A691AB /* RACArraySequence.m */,
-				5A8EE7EC34BC6EE2E2E9989ED0139B9F /* RACBacktrace.h */,
-				546BB867D098E9B9C3019D8541BE2EEC /* RACBacktrace.m */,
-				775477D4D81CB05B257641F615064B46 /* RACBehaviorSubject.h */,
-				E74AC17C2CF5C0313BB096210B7971E6 /* RACBehaviorSubject.m */,
-				D6D611AACFA11DA2CB730200A1E0F329 /* RACBlockTrampoline.h */,
-				4F4DF0C78D7F95F3A8AD05D71BF8AE24 /* RACBlockTrampoline.m */,
-				82B63627E1B60335529B0A85337DFBA2 /* RACChannel.h */,
-				C18E3C2B5B05581989FBAEE89CEFFEEF /* RACChannel.m */,
-				B27B1F5F1945C74B280C4507186F910D /* RACCommand.h */,
-				3CC78350520EF41E68B640BC8A5FEFFC /* RACCommand.m */,
-				B40962D8C0896819D87F62AB061E8D72 /* RACCompoundDisposable.h */,
-				59A69E01AD132247A736B86F90C02B00 /* RACCompoundDisposable.m */,
-				33BB7F6EE2D7770EC191EE930AC170EF /* RACCompoundDisposableProvider.d */,
-				EAE92CC7B639F6C34CD298AA41549D54 /* RACDelegateProxy.h */,
-				3BEFD09469425B8A59DD281F2D23A3F2 /* RACDelegateProxy.m */,
-				7AEF653A1037E7A89C1C1CC2732C30A8 /* RACDisposable.h */,
-				CD0C2EBA1F2CA0583C663B9A533E41EF /* RACDisposable.m */,
-				965931BB62C9B2A504512CA6A6208307 /* RACDynamicSequence.h */,
-				2FE3702BA7CD7C1EF918F1FFEC37B2E8 /* RACDynamicSequence.m */,
-				AA7F69B7E5EF12903A4332C83A36E21A /* RACDynamicSignal.h */,
-				6287254A6C5A7A83041A0DA692E17E9B /* RACDynamicSignal.m */,
-				6EB20819E758FF61FC1C313DF7D108D8 /* RACEXTKeyPathCoding.h */,
-				D2E3781B67B21441D53FA33F6A4AA633 /* RACEXTRuntimeExtensions.h */,
-				202BC15722571669D200E8ADA64B2BEB /* RACEXTRuntimeExtensions.m */,
-				3CD337E30EEDD66408D742FA6EE2BDC5 /* RACEXTScope.h */,
-				93BD16374160F79422053EFAAA3CC19C /* RACEagerSequence.h */,
-				093078FB8BCBB56AF0438DA3CBB45122 /* RACEagerSequence.m */,
-				4DD6B609F35559EA18FC4C6302ECF048 /* RACEmptySequence.h */,
-				69B70C7D88057FD710BE665508EA82C2 /* RACEmptySequence.m */,
-				DB58D49D15699D96337407A8A2C35AB4 /* RACEmptySignal.h */,
-				FA24CA8CDD807FAB5C75C3CBCD471603 /* RACEmptySignal.m */,
-				C0BAA20725F0829A4BDF98B119FB4D53 /* RACErrorSignal.h */,
-				9D1637BFAABEF75B5A08A03A500EC5C6 /* RACErrorSignal.m */,
-				201FB40811A25F91BC538292BFA9DFA3 /* RACEvent.h */,
-				9DBE53E0D0A9D6B0BA879F7EAD2C7310 /* RACEvent.m */,
-				F56B09E67C8713A35F5BF7D9A81009BF /* RACGroupedSignal.h */,
-				48F945F3F5C9B2F367CF1D04074E9063 /* RACGroupedSignal.m */,
-				1A3F63CEE7D957475C690D21744C92EF /* RACImmediateScheduler.h */,
-				EE6CA8DDEA2D1749EF81694FA0D05C7E /* RACImmediateScheduler.m */,
-				9A9866A5BC46C75E35E36D2666D8F997 /* RACIndexSetSequence.h */,
-				B99CFDFB66A3EF78E9CED6935D32E87B /* RACIndexSetSequence.m */,
-				E8BFF26288BA535373935740D7ADE254 /* RACKVOChannel.h */,
-				15EBEFF8684157C7D981950827C477A4 /* RACKVOChannel.m */,
-				2D775FFC9C2788090E0FB1EFFC080324 /* RACKVOProxy.h */,
-				64969607553A419F55D68772C21096C9 /* RACKVOProxy.m */,
-				0D8B40E1B9008EA8D876D4E2FC933EA2 /* RACKVOTrampoline.h */,
-				8A9D628F995FEC5E279B74E90E9733CA /* RACKVOTrampoline.m */,
-				AB1AAD99D6DC016BEB100A14C50706BF /* RACMulticastConnection.h */,
-				E9C694BE73E4F96617FAAF17E40ADE3C /* RACMulticastConnection.m */,
-				EF7557877A35947FBF94568558DCFAFA /* RACMulticastConnection+Private.h */,
-				CB51EBDAB2BA5E4AC46C870684FD6181 /* RACPassthroughSubscriber.h */,
-				E53AAAA4D493D789FCEA3BD930F01CCE /* RACPassthroughSubscriber.m */,
-				47A8BFEE5942CA0FD0E5E0BA5F323B30 /* RACQueueScheduler.h */,
-				A4FE3029CCF36904FE8E4599B033DD1A /* RACQueueScheduler.m */,
-				23F488A9B0F5CE26FC2321AF708C29B2 /* RACQueueScheduler+Subclass.h */,
-				A6E08205EDA9CBD3268E27962E943651 /* RACReplaySubject.h */,
-				BB54A9BD1067A9FBF329D95FB5C0E2F7 /* RACReplaySubject.m */,
-				666A9D1991710F8046A798389B986303 /* RACReturnSignal.h */,
-				52FA142C78437F9A9E4EBB03F89D1B27 /* RACReturnSignal.m */,
-				7BA24E93A8BA894A9E5B1817DF3310B3 /* RACScheduler.h */,
-				7EF167D699D7776368ACCC311AA44E95 /* RACScheduler.m */,
-				52A23864040D30E50974CD5F0DD11AE5 /* RACScheduler+Private.h */,
-				9013288D8F73306EBE028303FBD87338 /* RACScheduler+Subclass.h */,
-				8CFB9F140491EF5233B5B6DF1638D571 /* RACScopedDisposable.h */,
-				66E09C91E369C4586C4831F618F831AF /* RACScopedDisposable.m */,
-				5613A39E0CC3C230CD3DFE338FBD9D05 /* RACSequence.h */,
-				4041595FE659F3590E2DD68D1B6DB398 /* RACSequence.m */,
-				0A7FD71235C7DDFF3D97CB2A859A3AD7 /* RACSerialDisposable.h */,
-				D77B7E5726970936BB409415C276DBEC /* RACSerialDisposable.m */,
-				71DBD20BD7C22C7055FB294B58532346 /* RACSignal.h */,
-				C993BB7AE60C5F33AB04CD700CAC0629 /* RACSignal.m */,
-				942815D7546898BCF8AF15C5DC9625BE /* RACSignal+Operations.h */,
-				40269D438003ADFFC4896C29734DED55 /* RACSignal+Operations.m */,
-				CF9BAEC6203B0F46BCD1E3A74F4F14DD /* RACSignalProvider.d */,
-				9DBE662463B3987D25CEED40D39FB676 /* RACSignalSequence.h */,
-				01AE5DBAA417EF1DD630392B857C33E1 /* RACSignalSequence.m */,
-				C94E4E78014DCF2A5ED99F78C3BD69DC /* RACStream.h */,
-				FB7076DABFA78042AB6E9389ADAA9398 /* RACStream.m */,
-				9FE733D65B027C06DD030AD91BF135F8 /* RACStream+Private.h */,
-				A15C42C144EA0025F7F35F283F4E0E8F /* RACStringSequence.h */,
-				1500FDD1767362848287A77BAB4ACD64 /* RACStringSequence.m */,
-				7066A8216BB8CE14B85EEFD689CE5F8B /* RACSubject.h */,
-				44AB47B754C797DB20763B4DF661C931 /* RACSubject.m */,
-				02F56CE5B19A5F89FA9C32A454BF4C49 /* RACSubscriber.h */,
-				AFC35025FCE2CC972744BBF5FEF23360 /* RACSubscriber.m */,
-				81BCE78B3034395FE60BA9029C9BCED6 /* RACSubscriber+Private.h */,
-				69BCFE802A9187865C3913B48062E692 /* RACSubscriptingAssignmentTrampoline.h */,
-				21E2FDDD537A7835AB5F4AC1F5085CA2 /* RACSubscriptingAssignmentTrampoline.m */,
-				3B50757FB194775750692B1722CDA7EA /* RACSubscriptionScheduler.h */,
-				9850722D244E021478F2AFC9AFEA941A /* RACSubscriptionScheduler.m */,
-				6F457EA3AA515EF706FAE471958452D6 /* RACTargetQueueScheduler.h */,
-				3AC3C4882E27A01D5721D5AB3AE3A4A5 /* RACTargetQueueScheduler.m */,
-				B9B5E84290F765C88A7EE0A2AE61516B /* RACTestScheduler.h */,
-				E573CCE8C9DB021C3550C9E79F48B117 /* RACTestScheduler.m */,
-				14D377B47B7C7F6DBF87DC8722DF2895 /* RACTuple.h */,
-				1A30A796A4BA421118BCF4DA13978723 /* RACTuple.m */,
-				0C84D548FC73EA9BB169EE3019C1C0AF /* RACTupleSequence.h */,
-				FD71550502B7972F6A67439A7DFD00B9 /* RACTupleSequence.m */,
-				6BE4174116100A3787EC4636F12B6795 /* RACUnarySequence.h */,
-				F36D7D16B9DF57C4E4B5185F4FCDE9F5 /* RACUnarySequence.m */,
-				7AA002324460D09BB5D72A80C49FE986 /* RACUnit.h */,
-				1155C4A11B46AB9BFC5B32CE3C89B294 /* RACUnit.m */,
-				0F2E0A8616542DF80071FFE254B3EB9A /* RACValueTransformer.h */,
-				772170E58BDF4002BDDC78B04E11140F /* RACValueTransformer.m */,
-				018381EE57997B3F939BCEA6CC4FAD1F /* RACmetamacros.h */,
-				3E7656605139E2DF7947A1B93712E515 /* ReactiveCocoa.h */,
+				E5016E84FDB4BCEC51C4E89D1BADB318 /* Pod */,
+				F7DD42E5835141AC81D002D262FE3948 /* Support Files */,
+			);
+			name = ZettaKit;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		22E777E1587E69F10FD9FA89543674BD /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				5FF282FE24CC88B4329AEB0A042963DF /* Specta.xcconfig */,
+				3CACCA3C7D4A215EB291B39770BC52DB /* Specta-dummy.m */,
+				73C2AE7093A36EAEE5F6B1002D8D8E65 /* Specta-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Specta";
+			sourceTree = "<group>";
+		};
+		436062AAFE9AAF30964B59D089249629 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				24D95EF022E9831DEC806BFBFFBF4ED1 /* LICENSE */,
+				1D5EA101D113472F861FC70F08311BAE /* README.md */,
+				C22079DDCCC94EA5C5B5C9DF10ACC751 /* ZIKDevice.h */,
+				F733B8A74D4C6543D511798962A5F09D /* ZIKDevice.m */,
+				E87E3E3D6785A284165237B586375946 /* ZIKLink.h */,
+				837054C4375CF39A28CDD2D63B5782BA /* ZIKLink.m */,
+				9E4B3F96872494CD3F5BD32B2A635F07 /* ZIKLogStreamEntry.h */,
+				68FE83FABFC8584A26785B699BEC326C /* ZIKLogStreamEntry.m */,
+				DD724BBF5981B808BF260B8FB9864231 /* ZIKMultiplexStreamEntry.h */,
+				582592C4C062755C4FCCFCF63065992A /* ZIKMultiplexStreamEntry.m */,
+				A3FAFEC5430D762DDDD81D87E36ECF89 /* ZIKPubSubBroker.h */,
+				4D56DA445AE22C32F12F90665904C329 /* ZIKPubSubBroker.m */,
+				29BA88C63C3FFB93B343E609BFB36514 /* ZIKQuery.h */,
+				EC891F6742F11F128292B7A48860CAB4 /* ZIKQuery.m */,
+				A828718E304242EA2A84DA1F88812529 /* ZIKQueryResponse.h */,
+				5DAB30DEEBE9F3CB895D58BE6C2D5CA2 /* ZIKQueryResponse.m */,
+				87B68F4BCCBBD414A09F0FA3D01AF6F4 /* ZIKRoot.h */,
+				7B67C15C575D93F1F37E5CDB2B688E64 /* ZIKRoot.m */,
+				15B84CF3D4D844B8D622A71195CCF4DA /* ZIKServer.h */,
+				B9AB7070685988A22D4F17677BDDCB19 /* ZIKServer.m */,
+				B969DFDF184326B64EC3307A748DC45D /* ZIKSession.h */,
+				8BAF0ECCC13841E4CD4C8AF3D676DFCC /* ZIKSession.m */,
+				BBE9D05E4F9814E5F26DE9EEA47626B4 /* ZIKSpdyDelegate.h */,
+				0E41A919C897C4F73FBEF662DE23BAB8 /* ZIKSpdyDelegate.m */,
+				5839544CA403ECBB8310740DF5C90EDB /* ZIKStream.h */,
+				80DB5EEB97CD8E83D901212B91E0F111 /* ZIKStream.m */,
+				90F3434FA054544EA030674A851573A7 /* ZIKStreamEntry.h */,
+				503567FA56A67261C464A92973F0D03D /* ZIKStreamEntry.m */,
+				3F5696B17FB83D0EEC91FA13AC1DCC99 /* ZIKTransition.h */,
+				95E262ADE94CCA799941A74055041B23 /* ZIKTransition.m */,
+				D9FD2BDE956EE1E1B861F22E71D8DFEE /* ZIKUtil.h */,
+				2118C5E5E0E5926EBB1A7A4DE809F68A /* ZIKUtil.m */,
+				E7919C2B5B51C949D3AAD48EB7B41979 /* include */,
+				C25610528C4B39B4D778C081B9B64AA6 /* src */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		47052EA6A6295FBABCD647BB50D38AE3 /* Pods-Tests */ = {
+			isa = PBXGroup;
+			children = (
+				F4903BBCBAB13528A4A33BDA971FBDD2 /* Pods-Tests-acknowledgements.markdown */,
+				4B55035C92B38113F12159D6855B552E /* Pods-Tests-acknowledgements.plist */,
+				B0CE3A030FB80A882D8B46543CF5655E /* Pods-Tests-dummy.m */,
+				98A235811D5FE526242C4589C777B925 /* Pods-Tests-frameworks.sh */,
+				38B2AAFED4294A3C3DECB1A0A5B69904 /* Pods-Tests-resources.sh */,
+				6CDF80664B47D8E9EAA9B0A72C90C372 /* Pods-Tests.debug.xcconfig */,
+				42751639AEB7DB107D3E464F4F222E89 /* Pods-Tests.release.xcconfig */,
+			);
+			name = "Pods-Tests";
+			path = "Target Support Files/Pods-Tests";
+			sourceTree = "<group>";
+		};
+		64DA8BF3DEC67EC7C0B2D087F488C6DF /* Pods-ZettaKit */ = {
+			isa = PBXGroup;
+			children = (
+				9FB41FF7D92DA5FE1C7F0E9D52669738 /* Pods-ZettaKit-acknowledgements.markdown */,
+				080B839C81F8D14FF1FC7F76F5105F20 /* Pods-ZettaKit-acknowledgements.plist */,
+				47ED70C198D1C27DB8FA33274F0DFE53 /* Pods-ZettaKit-dummy.m */,
+				A3E8D006D5A26EF45A3BF7B3823DF667 /* Pods-ZettaKit-frameworks.sh */,
+				CF2365119D4033CBCE693DE31B43892A /* Pods-ZettaKit-resources.sh */,
+				B06C9DB1C4CBEDD9663F665AFD3E0335 /* Pods-ZettaKit.debug.xcconfig */,
+				D215B9F08998FEE6B350456C4A96BBE4 /* Pods-ZettaKit.release.xcconfig */,
+			);
+			name = "Pods-ZettaKit";
+			path = "Target Support Files/Pods-ZettaKit";
+			sourceTree = "<group>";
+		};
+		651733BA43AB4A82DC08C36C40BD9FB8 /* ReactiveCocoa */ = {
+			isa = PBXGroup;
+			children = (
+				69B3FD693EAD24B61CC76A3037C1C6FC /* Core */,
+				66E0E4CEDA810DC737D2959695CEC2E7 /* no-arc */,
+				B7DF290E22E11016ACA47F65CFA86362 /* Support Files */,
+				A4E28D15E4E0FECAC0F5CFA5D55B080F /* UI */,
+			);
+			path = ReactiveCocoa;
+			sourceTree = "<group>";
+		};
+		66E0E4CEDA810DC737D2959695CEC2E7 /* no-arc */ = {
+			isa = PBXGroup;
+			children = (
+				399EFA25E90256DE4C1D6345BBDC959E /* RACObjCRuntime.h */,
+				6B2E69941158970F9E10E899F014394A /* RACObjCRuntime.m */,
+			);
+			name = "no-arc";
+			sourceTree = "<group>";
+		};
+		69B3FD693EAD24B61CC76A3037C1C6FC /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				E2DA78ED7A84B4444BABBB71B33945E4 /* NSArray+RACSequenceAdditions.h */,
+				76B498C82759B692E86E52E1FA42AB05 /* NSArray+RACSequenceAdditions.m */,
+				06F21B162DD79BC9EED0217C3F40AC5A /* NSData+RACSupport.h */,
+				45719AACD7A6ED9EEF636B59ECAC2629 /* NSData+RACSupport.m */,
+				1905B74F63A0AD41B1CAD8A862561A81 /* NSDictionary+RACSequenceAdditions.h */,
+				807E74E375C9672962E7B791FA604FF2 /* NSDictionary+RACSequenceAdditions.m */,
+				6F059BE23CB9165E492C5F0D8CF842FB /* NSEnumerator+RACSequenceAdditions.h */,
+				E010C8D6AF601EA5598C256C26939290 /* NSEnumerator+RACSequenceAdditions.m */,
+				4FB301C423E470ABC52402A4D9C0B018 /* NSFileHandle+RACSupport.h */,
+				94F844683B588ECDCCAA89CEC01236E8 /* NSFileHandle+RACSupport.m */,
+				A143A972676B0E346EE156FD625C4276 /* NSIndexSet+RACSequenceAdditions.h */,
+				CB02C0E54D42481A62AD3089B3401E7E /* NSIndexSet+RACSequenceAdditions.m */,
+				23613F8E6C3F6F16E151C793E6D80285 /* NSInvocation+RACTypeParsing.h */,
+				F3AD4536DE30D8EA87417415F662E8AC /* NSInvocation+RACTypeParsing.m */,
+				51F4BDC233123AE3A9EA3A038DF8D2A9 /* NSNotificationCenter+RACSupport.h */,
+				BA38B6970BF21C123385A2564938F23B /* NSNotificationCenter+RACSupport.m */,
+				F45459ED42E2368FF604F6EDFE0DC4BC /* NSObject+RACDeallocating.h */,
+				29D437BACC065C49426D20FC1069D176 /* NSObject+RACDeallocating.m */,
+				E90A7CB9AA7BD637450DFD338647C738 /* NSObject+RACDescription.h */,
+				1B441EB635414EDF074BAEF21B2058BD /* NSObject+RACDescription.m */,
+				465F150AE4860D39F54E78F690CD3588 /* NSObject+RACKVOWrapper.h */,
+				7F890F72C0602F1B7621CB4BA83BF8F0 /* NSObject+RACKVOWrapper.m */,
+				B27E36761CD140C7DC3B21DED464A3CF /* NSObject+RACLifting.h */,
+				460945DB57E6AE36593F74CBC5E10972 /* NSObject+RACLifting.m */,
+				81CC7B09121CC961047AD9C78F37DD61 /* NSObject+RACPropertySubscribing.h */,
+				AF685F09A7816D23974C4C4CE728EB4C /* NSObject+RACPropertySubscribing.m */,
+				4E7B3C5CC96F782C2D3FE5DEEB74B7E8 /* NSObject+RACSelectorSignal.h */,
+				F74B076165239E6B1C2A4B47523C4E99 /* NSObject+RACSelectorSignal.m */,
+				D98D0755963DF1A845362000E59B8A12 /* NSOrderedSet+RACSequenceAdditions.h */,
+				C3FB06352F57BA378EE5504B0CF015A0 /* NSOrderedSet+RACSequenceAdditions.m */,
+				CE53639CC6731F2B6329A8D56BFB7062 /* NSSet+RACSequenceAdditions.h */,
+				C70DFD84E18AC5029210185A3C7E47B0 /* NSSet+RACSequenceAdditions.m */,
+				B5F1B078832036E8314B365385207243 /* NSString+RACKeyPathUtilities.h */,
+				575E18E6D08A71A94D6B62266BAB5CD3 /* NSString+RACKeyPathUtilities.m */,
+				D7FC17245AD1982B1BD013D6BE7A23A2 /* NSString+RACSequenceAdditions.h */,
+				B29209402CC5FAFCD53FBC0B40BDC3FF /* NSString+RACSequenceAdditions.m */,
+				DA6D71F184E95740920E1C34D7E76253 /* NSString+RACSupport.h */,
+				C586B801A1C62272EEE24D11EF15743F /* NSString+RACSupport.m */,
+				67D9E087FCDD73C160E78A97F13C3118 /* NSURLConnection+RACSupport.h */,
+				B47DF783A0B3BF4CF5E21E48D635B563 /* NSURLConnection+RACSupport.m */,
+				0F3B77BC3EA9EC34306989CEEA919CBC /* NSUserDefaults+RACSupport.h */,
+				2F3586C221621D26A3BB8500E26980E4 /* NSUserDefaults+RACSupport.m */,
+				1C97FF8DF5E082F83910AA7BE2CAB1D5 /* RACArraySequence.h */,
+				B9100F21CA0D4E47FCF754BAB371F609 /* RACArraySequence.m */,
+				11BD458135FCFC30F9EF63C65CEEF3C1 /* RACBacktrace.h */,
+				4E740B8E7A504CC5E613EFD01A9F4EBE /* RACBacktrace.m */,
+				0441E0AE32C0F44CE9A33ACF69DD6B3A /* RACBehaviorSubject.h */,
+				A9FDD0D041D126568C997F923FEA26F6 /* RACBehaviorSubject.m */,
+				381EC98E8D5A8F00FF27E6A6052ADBB9 /* RACBlockTrampoline.h */,
+				4E5D7FCCFEAB0E4BE322D6EDA4EDFD65 /* RACBlockTrampoline.m */,
+				FEA8575E86EB20883AF962870025D142 /* RACChannel.h */,
+				E62CAC8621BAF233839416A17F5DB8A5 /* RACChannel.m */,
+				157D07568C7D5456875136D836176D39 /* RACCommand.h */,
+				11FD7D57E6869773BA8B6976BDE365CC /* RACCommand.m */,
+				F7AFDE4EF1DB9F469D6328E574A3DA71 /* RACCompoundDisposable.h */,
+				24B1817A010990A13217A95AB7ABAD59 /* RACCompoundDisposable.m */,
+				AC59CA58F43E0327E7D352F6665E4E00 /* RACCompoundDisposableProvider.d */,
+				63C90E38CD895BD45DA691C1658C0499 /* RACDelegateProxy.h */,
+				D5497F7C0AD1EA4BDA02871EE42B3772 /* RACDelegateProxy.m */,
+				BD111E8EBE043F3CD4204A51FFE005AA /* RACDisposable.h */,
+				21AD5F2D89A56E7D9D50A91C60983476 /* RACDisposable.m */,
+				0FC0985E7655086F972C557018F0DA42 /* RACDynamicSequence.h */,
+				7DFA37545B55B0300E856938EB73FFC7 /* RACDynamicSequence.m */,
+				17EFEDDED7A7C8597D989FAA6D116C0A /* RACDynamicSignal.h */,
+				D385992879D7D7C6C5607ADF621CFA25 /* RACDynamicSignal.m */,
+				5C15EDA1D8F7B024C74EAB84E6A53A6F /* RACEagerSequence.h */,
+				000F856D7101A8BC6B178670BC643798 /* RACEagerSequence.m */,
+				9329180DD4BBB481648E2F4FFDE51D81 /* RACEmptySequence.h */,
+				5051018961F950EBF8F277B64ABB2C0B /* RACEmptySequence.m */,
+				9D783B3F6E90DBF51FE96E0D36EB7FEF /* RACEmptySignal.h */,
+				3D9B11BD99BCF95BA193809C6D3C65FA /* RACEmptySignal.m */,
+				814EF461030D50A1EC6A00CA40AE3328 /* RACErrorSignal.h */,
+				8871C1DA358494BCB93C7EF46B001011 /* RACErrorSignal.m */,
+				1164F0FC120495823065569EDEF28865 /* RACEvent.h */,
+				C730C42C7E0A20FBC8D5C14FD1F2A2D6 /* RACEvent.m */,
+				9510AD3BA0C99858102DD0BA82B890D8 /* RACEXTKeyPathCoding.h */,
+				59439829E3C4E56FBAE4F00E266E1A37 /* RACEXTRuntimeExtensions.h */,
+				5C5715548587871DFC3A3B71BCE2CCAD /* RACEXTRuntimeExtensions.m */,
+				01D0FF60BEAF1393227B134181A3B434 /* RACEXTScope.h */,
+				F50671E063EFF82A71D6980CF8CC780F /* RACGroupedSignal.h */,
+				B5714F791BD7855787CD63418474CF0D /* RACGroupedSignal.m */,
+				C5BB01A6E736EEB18B3787A032A944B9 /* RACImmediateScheduler.h */,
+				AAA71D1183F9825A15F96A30A5565DCE /* RACImmediateScheduler.m */,
+				B73C8F282C3073E55887901D2522015F /* RACIndexSetSequence.h */,
+				F5EFD47E28DABDF59B64F97718E9F69E /* RACIndexSetSequence.m */,
+				6D5F26C36098801DA4B1D3E84AE8E441 /* RACKVOChannel.h */,
+				76B5A6511E6248F836C83CEA0678F8D8 /* RACKVOChannel.m */,
+				5A2CA17C9DE8F94CC438954C0FDFE08C /* RACKVOProxy.h */,
+				7807F865B6F9BCA550F3FF9019137099 /* RACKVOProxy.m */,
+				FD1C69C1991C3CF4E814739A96FC8286 /* RACKVOTrampoline.h */,
+				12623E9C076D6851E80570E62515A38B /* RACKVOTrampoline.m */,
+				2B432DFCA87CF1FB63A6D5DCF79AF84E /* RACmetamacros.h */,
+				841B00772D329753B4025722551543FB /* RACMulticastConnection.h */,
+				9E6CF1CA72EFBF01AC43ACE22B33C14F /* RACMulticastConnection.m */,
+				B2CEBD589001912EA1B56EBB19A47074 /* RACMulticastConnection+Private.h */,
+				87446A059E2B640EB4228A281551157B /* RACPassthroughSubscriber.h */,
+				FCBBEF829D436ED24146C3AB1FEC7F08 /* RACPassthroughSubscriber.m */,
+				5A693EA863B53FF281CA1C475ED8BBD6 /* RACQueueScheduler.h */,
+				83997E2AD682AE9A1F41047F2B0EFC47 /* RACQueueScheduler.m */,
+				F4D5E05A7D460BD2A65B28AE99BA1548 /* RACQueueScheduler+Subclass.h */,
+				8B9DC7FE487BD7419DBC28A08E1CDB4F /* RACReplaySubject.h */,
+				2053CD78FFD7A94ECDB6E8E14467A2E5 /* RACReplaySubject.m */,
+				25F6B15249280120AA30CF1F70DAB036 /* RACReturnSignal.h */,
+				C7FCAF3EBC70368E629E896F4764C1F7 /* RACReturnSignal.m */,
+				4311F1F4907F6B5122084AB91187F1FC /* RACScheduler.h */,
+				724F059E82DB0D20ABEBC23776B78778 /* RACScheduler.m */,
+				AB7957E12585177C35D695172EF7ADEE /* RACScheduler+Private.h */,
+				BCDE9C15A3117F912F32E8E2CF695BC4 /* RACScheduler+Subclass.h */,
+				D0FEE08548DBA391864FE3E42D81E8AB /* RACScopedDisposable.h */,
+				FE90FFC1AF01086A63A326DB289CBE9E /* RACScopedDisposable.m */,
+				F95948394EDCC4FDBCD734B8878D4125 /* RACSequence.h */,
+				5FFDC4DF7EFC3EB7B20C19CEE4FFA320 /* RACSequence.m */,
+				425DA1B18BCD936BCD045C30033B2060 /* RACSerialDisposable.h */,
+				DCAAF1157A4C0916378424BC991B201A /* RACSerialDisposable.m */,
+				736866F02218EA68B125AE95FC10C3A1 /* RACSignal.h */,
+				D7C60040C68FBC58D2E7DF1B23E69C65 /* RACSignal.m */,
+				EA8E021EED935A5BC1072A2C2F1D71DF /* RACSignal+Operations.h */,
+				C7D7BA73518CF55B05357AE182F56818 /* RACSignal+Operations.m */,
+				47CE1F61B9188398391D67DF09B0C0C0 /* RACSignalProvider.d */,
+				E347C79F678AADEDC3D049EB0731C9E2 /* RACSignalSequence.h */,
+				E7ECB7C85249865798147B9AFCEE268F /* RACSignalSequence.m */,
+				7D291EB38672207FFB7F6315E56AE2DE /* RACStream.h */,
+				1577B7A21955232EB2572EBB20B0D63C /* RACStream.m */,
+				23C8257ADCC63FF10D8315B65EAB1C30 /* RACStream+Private.h */,
+				DBA80C890500B9F22A637FC3526C1F33 /* RACStringSequence.h */,
+				7159390A93C56E54C7582B79460869BA /* RACStringSequence.m */,
+				104A9EDF53C855F535C4ECAFDB2AFE40 /* RACSubject.h */,
+				CB637AFECB15359174697DC08B4322A9 /* RACSubject.m */,
+				6806715BC9D98C550266073CCF5A36FD /* RACSubscriber.h */,
+				0AF69967B99B1113F1F14D00B282D8FF /* RACSubscriber.m */,
+				F4CA3F42064F3B1D70243E0FB95B971A /* RACSubscriber+Private.h */,
+				7B1344906DCF6EFB4829EBAAEE7ACEE2 /* RACSubscriptingAssignmentTrampoline.h */,
+				9713019DD4155A06917612BBB9819D0B /* RACSubscriptingAssignmentTrampoline.m */,
+				474D4012450619FE1462FE15FCB301AE /* RACSubscriptionScheduler.h */,
+				DACB96CFE80FED9F7622FCED70899ACD /* RACSubscriptionScheduler.m */,
+				52C1DFBAACDC4D0D29AB1B7A91239C46 /* RACTargetQueueScheduler.h */,
+				06E5982576957E4346DB04D83B0F8783 /* RACTargetQueueScheduler.m */,
+				2730914A537D4010675370C90905A9E0 /* RACTestScheduler.h */,
+				F28104D710F12599910B64C3A4461F10 /* RACTestScheduler.m */,
+				6B452F53FC4F7777F91C800ABB6DE335 /* RACTuple.h */,
+				EF2E91920AC3F02EFF7D63150776BA92 /* RACTuple.m */,
+				5F85C712B1D6545F7FC0D5F7A09B7E70 /* RACTupleSequence.h */,
+				8B36EBF9EC8D2879793B47CBFF2EF1DC /* RACTupleSequence.m */,
+				7072B2420C871B152E0C0C9CB4226C6D /* RACUnarySequence.h */,
+				D5AE802408CB4E2D6331A7EBD0556835 /* RACUnarySequence.m */,
+				7F25A9DF41A6B6F8A96D43FE0C734D55 /* RACUnit.h */,
+				6D521BB6601809129D7B55C9FD759530 /* RACUnit.m */,
+				452246F4F6CB6AB7740F5AEF7ADA1527 /* RACValueTransformer.h */,
+				BBF9A6B773BD0568DD8D50E62D6B86B3 /* RACValueTransformer.m */,
+				F7E2504F66F29BA0C91B7EB79EDDF056 /* ReactiveCocoa.h */,
 			);
 			name = Core;
 			sourceTree = "<group>";
 		};
-		770BFF60B39DD857360EFBD0B1EFC837 /* UI */ = {
+		6F58920903E0C65FA93344E0C2D7C8C1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				741EFB39BE7A75F8318655D9633AAD92 /* UIActionSheet+RACSignalSupport.h */,
-				C61741E1194F8E72D51E3A65260818F5 /* UIActionSheet+RACSignalSupport.m */,
-				CE4E8E2AA00AF5EC79748FAD200C21A1 /* UIAlertView+RACSignalSupport.h */,
-				04D46DBAD30879A86FBEE7ED8EFC736B /* UIAlertView+RACSignalSupport.m */,
-				6785E4D735DDD2CE69A963A4AF5EE599 /* UIBarButtonItem+RACCommandSupport.h */,
-				B168AC1BB12F4DE7CB999A34B9EE6FAB /* UIBarButtonItem+RACCommandSupport.m */,
-				21E1481F317AA4D3FA9E8B4431E6E873 /* UIButton+RACCommandSupport.h */,
-				27A36CEF3E5D04D7B9EDA2B6C0ED5197 /* UIButton+RACCommandSupport.m */,
-				CD275CF459A5ADA1EE193B6FACF58D60 /* UICollectionReusableView+RACSignalSupport.h */,
-				A4881E3CE72C3AADAE5448C921A461EB /* UICollectionReusableView+RACSignalSupport.m */,
-				2E7418D91B25E6D9AA392FE90B771BF6 /* UIControl+RACSignalSupport.h */,
-				4261CD967FB77A20DA53A438C37DF7C1 /* UIControl+RACSignalSupport.m */,
-				86B87C7E3D18D5348EB52D09B39E0BDF /* UIControl+RACSignalSupportPrivate.h */,
-				929D00BB58123B006BFD678778A36407 /* UIControl+RACSignalSupportPrivate.m */,
-				47B8C4F1228CB66BA3181891CBA0DB4E /* UIDatePicker+RACSignalSupport.h */,
-				2D68B7CE019CBAA096DDE45EB2D6A056 /* UIDatePicker+RACSignalSupport.m */,
-				BFCA99B5C0AA2B98264CB07A3110BB66 /* UIGestureRecognizer+RACSignalSupport.h */,
-				21003E153499263B2F932EDD9F77F1DF /* UIGestureRecognizer+RACSignalSupport.m */,
-				674EFBE953AD3B06A235EC0B5C0E8D50 /* UIImagePickerController+RACSignalSupport.h */,
-				F1C12C84BECEA822C8E998EDCA34F85C /* UIImagePickerController+RACSignalSupport.m */,
-				EC5D8D51CFD27A8625EFFDB8914EA523 /* UIRefreshControl+RACCommandSupport.h */,
-				764CC59FC8A9C5A716530F6C0633CA36 /* UIRefreshControl+RACCommandSupport.m */,
-				9531E303E9D2A1C6DAAA81D34EBB14F4 /* UISegmentedControl+RACSignalSupport.h */,
-				40FE3B185463A321496134062A3DEED8 /* UISegmentedControl+RACSignalSupport.m */,
-				829D27E4966BA9A9DFC007200AEF9351 /* UISlider+RACSignalSupport.h */,
-				2F615E19B20280D1880B90357C80B364 /* UISlider+RACSignalSupport.m */,
-				EA9D007B04968D2533787298BE4632D5 /* UIStepper+RACSignalSupport.h */,
-				9A3F65A8A96CE404922B21DD9E38AAB9 /* UIStepper+RACSignalSupport.m */,
-				9D6B5E91193C842C95227E963B247EE3 /* UISwitch+RACSignalSupport.h */,
-				ACE6B769E901D0C368B7418D4B98292D /* UISwitch+RACSignalSupport.m */,
-				E48C2BFC97916C067AFA88FCDBA67769 /* UITableViewCell+RACSignalSupport.h */,
-				85E6FA106E095C348CFBAE1AA3DF9BE2 /* UITableViewCell+RACSignalSupport.m */,
-				FAB36299CB4895BFB612150AED6E9436 /* UITableViewHeaderFooterView+RACSignalSupport.h */,
-				25C2836BCC935BD8A46E618D13184C36 /* UITableViewHeaderFooterView+RACSignalSupport.m */,
-				D2CB2CF0F32C1F316D49FB54DEB6AFCC /* UITextField+RACSignalSupport.h */,
-				D04F30589CA7E633520E1BF71902834B /* UITextField+RACSignalSupport.m */,
-				092669775C6D16219510B67D37706726 /* UITextView+RACSignalSupport.h */,
-				751B822306AAB8E017F2D3241CF6AF3E /* UITextView+RACSignalSupport.m */,
+				E05781440EB77042BAF5684942D1CC21 /* libExpecta.a */,
+				FA4A7BB2D43ACEBC39C6CFFAD1E9763C /* libPods-Tests.a */,
+				710763F27A87396FAF50139B3A244876 /* libPods-ZettaKit.a */,
+				9E5D9AF4757F7C84882EBD74C7801A4D /* libReactiveCocoa.a */,
+				DFBFD1EA2F0596148164F4C0A56247FB /* libSocketRocket.a */,
+				32009289A420396C11D7461A264B8B09 /* libSpecta.a */,
+				8D0862DFD1128B1E6C745191A5B7547F /* libZettaKit.a */,
+				B8EEF3578F570DFB16E2C0FD25D44FE5 /* ZettaKit.bundle */,
 			);
-			name = UI;
-			sourceTree = "<group>";
-		};
-		779C20AFF91CD351FF9CB0EFFA521F83 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				2378C33D018E20044A36D69501782721 /* Pods-Tests */,
-				A1BA135CFF1A4942916CB6E41E766426 /* Pods-ZettaKit */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		7D84F2B7A4452D2414C8A32573EADEB8 /* no-arc */ = {
-			isa = PBXGroup;
-			children = (
-				93136A340786946A1744EEF21ADB3813 /* RACObjCRuntime.h */,
-				D0F81A33D63E139320DC075C646EC4CD /* RACObjCRuntime.m */,
-			);
-			name = "no-arc";
+			name = Products;
 			sourceTree = "<group>";
 		};
 		7DB346D0F39D3F0E887471402A8071AB = {
@@ -1274,533 +1216,501 @@
 				8692AC04FC24BEDFD7A5A8D056C1A40C /* Development Pods */,
 				14B8B9B15ECBE87983FF987239AB2D7B /* Frameworks */,
 				0A91B73A2D74B7FDA8724584C38C3B5D /* Pods */,
-				CCA510CFBEA2D207524CDA0D73C3B561 /* Products */,
-				779C20AFF91CD351FF9CB0EFFA521F83 /* Targets Support Files */,
+				6F58920903E0C65FA93344E0C2D7C8C1 /* Products */,
+				F096FA6EC9D558668710C851FE2EBF9D /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
 		8692AC04FC24BEDFD7A5A8D056C1A40C /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A3C32F80CAF48B0613A9A55858F1ACFE /* ZettaKit */,
+				158331223CBDA07DF0D10895C856C31F /* ZettaKit */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		8814A0AD0C11DE7AEC4C587C817E4826 /* SocketRocket */ = {
+		A4E28D15E4E0FECAC0F5CFA5D55B080F /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				29DF0EB3518882D15FABD9EE8F48A47E /* SRWebSocket.h */,
-				56971F82844624B96D2ACDA30390A280 /* SRWebSocket.m */,
-				E10F7E980C086EC941E92049790546CD /* Support Files */,
+				E804BEF49DE6021B2954A1A5B5EEB4B2 /* UIActionSheet+RACSignalSupport.h */,
+				59F70B8A4A66AFA5FB397B79FC0491C0 /* UIActionSheet+RACSignalSupport.m */,
+				E8CDF624776F41717486C9D5AE245F7A /* UIAlertView+RACSignalSupport.h */,
+				EEEEB648BD8D739F858FB6CB3861E4C7 /* UIAlertView+RACSignalSupport.m */,
+				90488EF47B11B7F603A859F3742766FB /* UIBarButtonItem+RACCommandSupport.h */,
+				8E62896D68CA3F0A194330B49E02FE5D /* UIBarButtonItem+RACCommandSupport.m */,
+				B4F1F165027F1342BCB947165A752CC9 /* UIButton+RACCommandSupport.h */,
+				1C209576F7E761D74D71364070C65292 /* UIButton+RACCommandSupport.m */,
+				AC0285802CDE6C920B3F48A3F31E1A59 /* UICollectionReusableView+RACSignalSupport.h */,
+				DC72857955E930399D1DBEBF2586F413 /* UICollectionReusableView+RACSignalSupport.m */,
+				9A56037B984AFB4991EEF77C5FE65301 /* UIControl+RACSignalSupport.h */,
+				7265403BB611452813B830384C77018E /* UIControl+RACSignalSupport.m */,
+				3BE9DB8559FD1A1D949D1001463622D3 /* UIControl+RACSignalSupportPrivate.h */,
+				6DB0504CF54F499FF286E6877F3115F7 /* UIControl+RACSignalSupportPrivate.m */,
+				14F250AC55FCD6D4FBC738496A747132 /* UIDatePicker+RACSignalSupport.h */,
+				C57CA92BD28AAA882016E954BF09B40A /* UIDatePicker+RACSignalSupport.m */,
+				621D4D723DBE7D4218665E0AC1342C51 /* UIGestureRecognizer+RACSignalSupport.h */,
+				FF786D8F7275F32CBABED40CC560AB48 /* UIGestureRecognizer+RACSignalSupport.m */,
+				CC2DEA8F4D7EE3348CEC9E09385CAC55 /* UIImagePickerController+RACSignalSupport.h */,
+				E08532A1035BC677EC5CEB789B819C57 /* UIImagePickerController+RACSignalSupport.m */,
+				EEED1796FF1FF9C0FF40280379C00BC9 /* UIRefreshControl+RACCommandSupport.h */,
+				6A582BDE6093D34AD109839CD6A0EFAB /* UIRefreshControl+RACCommandSupport.m */,
+				76259B99B9234E4C2F2E8CF21AA70293 /* UISegmentedControl+RACSignalSupport.h */,
+				E891EC269F94FE9E1F4DD7CABA531177 /* UISegmentedControl+RACSignalSupport.m */,
+				42F6556ABDF624E54F294C42FC4849A8 /* UISlider+RACSignalSupport.h */,
+				0D4F8DF26508CB420029A380B8B02444 /* UISlider+RACSignalSupport.m */,
+				5042AA968A0ABDBE3871B7622F78EB26 /* UIStepper+RACSignalSupport.h */,
+				E64DA99843772788110E16DF50E93BE4 /* UIStepper+RACSignalSupport.m */,
+				8A2E2EB23E9C08AB9237C9153C153BD5 /* UISwitch+RACSignalSupport.h */,
+				62FFBD32F4A55C1B67C8700F14AD271B /* UISwitch+RACSignalSupport.m */,
+				C81DB42D73B489E1BF1C967655FE2481 /* UITableViewCell+RACSignalSupport.h */,
+				C8E5B0E6B099D2FAC8CA2E85AC0D6BAB /* UITableViewCell+RACSignalSupport.m */,
+				F50DEA32B696B39BFDC9D19F8BA3D6D9 /* UITableViewHeaderFooterView+RACSignalSupport.h */,
+				2C085E99658A5F1CEFB72E60107415DF /* UITableViewHeaderFooterView+RACSignalSupport.m */,
+				3E928B4F0D64608EEBF469AFCF96AD9D /* UITextField+RACSignalSupport.h */,
+				819F476B597E5250D35F6C4E679C248A /* UITextField+RACSignalSupport.m */,
+				2C974A4094111CAC8D6AA56AE309A3EC /* UITextView+RACSignalSupport.h */,
+				63FFDD270ED91A2E840E585A1C2F75CB /* UITextView+RACSignalSupport.m */,
 			);
-			path = SocketRocket;
+			name = UI;
 			sourceTree = "<group>";
 		};
-		A1BA135CFF1A4942916CB6E41E766426 /* Pods-ZettaKit */ = {
+		AAA375ABFA2B1B89C94870DBDBF0EFDA /* Specta */ = {
 			isa = PBXGroup;
 			children = (
-				4ADEA058D137A5E214779E450F9E09A0 /* Pods-ZettaKit-acknowledgements.markdown */,
-				11E3E46C97AE920E685285051A98DB34 /* Pods-ZettaKit-acknowledgements.plist */,
-				3A72AA5D46AE85EF9B309863E64165F2 /* Pods-ZettaKit-dummy.m */,
-				8E39002BCCF999437DDDD26D78952B93 /* Pods-ZettaKit-resources.sh */,
-				50CAB6E112050E908BCE5A95DBBAE81A /* Pods-ZettaKit.debug.xcconfig */,
-				EC1C002644E52229F4C9680EDF9B78B2 /* Pods-ZettaKit.release.xcconfig */,
+				F707E0E883A4C7537200AAD0D1C70533 /* Specta.h */,
+				C95BC3D2F89DB47545476BC0D3F87139 /* SpectaDSL.h */,
+				4C1D35FD2393D0DD8805C9D2AE11B97E /* SpectaDSL.m */,
+				CEE15BB7927F71C5EF0D9944E49C3D15 /* SpectaTypes.h */,
+				E2EAAD5DBE06A90DC1F3840D8D719E8B /* SpectaUtility.h */,
+				2C5BBEF39456C0740E171C5A1F4E5ABE /* SpectaUtility.m */,
+				C7207F073F97144F41D3C4EC324DC3DD /* SPTCallSite.h */,
+				51625C5FA086FBCD75EB57ADEF8462DB /* SPTCallSite.m */,
+				91DDBAB553306DD9C134557FA8B17A80 /* SPTCompiledExample.h */,
+				48E8266023F937C3457AEDD4178FAECC /* SPTCompiledExample.m */,
+				C74D1B18DA9E5234519F4B2CF6043A48 /* SPTExample.h */,
+				F41771A261A6A0500C7457CD20437474 /* SPTExample.m */,
+				8D37009F319795E9375273A4713949CB /* SPTExampleGroup.h */,
+				C6AB7BF63C59F61D644EEA4EE631F35C /* SPTExampleGroup.m */,
+				87F7C8BCB22AD58A12B1572315D52A0A /* SPTExcludeGlobalBeforeAfterEach.h */,
+				A91C258A43D5ADFF9475D12895F61411 /* SPTGlobalBeforeAfterEach.h */,
+				7AAFF20402CE303809D9FABBAD5C779C /* SPTSharedExampleGroups.h */,
+				446F933EE90F1244D8D8CA265DBAEB44 /* SPTSharedExampleGroups.m */,
+				197774D0AD9720DC6EE0303C68AA39FE /* SPTSpec.h */,
+				21BA92377EADEDD7FA95EF7366D46690 /* SPTSpec.m */,
+				0064A5DFABE906B13C10F14A5268E78D /* SPTTestSuite.h */,
+				EEBAFFBA3116126B88A2E528C1DA6ACF /* SPTTestSuite.m */,
+				80F8E76076FC9F2A52A8D699305B5574 /* XCTest+Private.h */,
+				E93F5443A0C67A0886A6B4A4B9DD9D4C /* XCTestCase+Specta.h */,
+				496296157B5A145E2E82456EEDCABC9C /* XCTestCase+Specta.m */,
+				22E777E1587E69F10FD9FA89543674BD /* Support Files */,
 			);
-			name = "Pods-ZettaKit";
-			path = "Target Support Files/Pods-ZettaKit";
+			path = Specta;
 			sourceTree = "<group>";
 		};
-		A3C32F80CAF48B0613A9A55858F1ACFE /* ZettaKit */ = {
+		B7DF290E22E11016ACA47F65CFA86362 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				6B6737CB05AAA21B0C9D8370E9C57EB0 /* Pod */,
-				DAEC7FA40AA17357D5F9F4058CE54D4E /* Support Files */,
-			);
-			name = ZettaKit;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		AFC2AFEF9289671F36B404AACD0D1BEA /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				E97AD6B9417405A4D6A9DF2773C99A33 /* LICENSE */,
-				A24DF0C64AACE3F56BA0F5EF133BB532 /* README.md */,
-				EBB6A2AC8482158DD065C6E623FB57E3 /* ZIKDevice.h */,
-				65963049F3D276A28B72275D08D742DE /* ZIKDevice.m */,
-				CACD8F5BA506CEE1FED45B9C706E62CF /* ZIKLink.h */,
-				A3744DA45A5C7438CFFD2FE1721C0916 /* ZIKLink.m */,
-				82E526B3AAC4E22005C261AC77230110 /* ZIKLogStreamEntry.h */,
-				652B1FA7612CE62122306687D3107D75 /* ZIKLogStreamEntry.m */,
-				01FF14C73FA1CE2B9EDC4A39A0EEECA6 /* ZIKMultiplexStreamEntry.h */,
-				902F5FD98CA6F8F6FF159687D5ECD159 /* ZIKMultiplexStreamEntry.m */,
-				51B318510EF225CFC16F065802B4375B /* ZIKPubSubBroker.h */,
-				E9AFFE6627D3125C9855BCBCA525AE0E /* ZIKPubSubBroker.m */,
-				C525C73AA385D16886B341BFA97FE274 /* ZIKQuery.h */,
-				4D824F85C9A3F2F486A719978CC0B4E9 /* ZIKQuery.m */,
-				5EBA97F8EE77602656B8F3244AEB15A8 /* ZIKRoot.h */,
-				33BE1AFB3E5E4655FB27567CB70D9911 /* ZIKRoot.m */,
-				BDCB5CEF1814EC7E43CB748B6C1D2A2E /* ZIKServer.h */,
-				9E3C036B04A117673C553EBA1E274209 /* ZIKServer.m */,
-				7EC8491A58BF2C5E2E76D9B29E3D1A3B /* ZIKSession.h */,
-				8AA55823DB3770639916D4F68BCA4028 /* ZIKSession.m */,
-				78344F6C65F3DCF875A9EC8F70750528 /* ZIKSpdyDelegate.h */,
-				FBE7B5E036C81297BF24E9A54E824975 /* ZIKSpdyDelegate.m */,
-				4BC55603216527453AE4FB44CC0B3B1A /* ZIKStream.h */,
-				85E1916DC30855C0CF4C5FD890F34811 /* ZIKStream.m */,
-				BBABF04D8BD625E55C45D08668540043 /* ZIKStreamEntry.h */,
-				DEED4633D5172B82272BC373AEC78624 /* ZIKStreamEntry.m */,
-				60638554325FEAC8776DDAE4CCDE5633 /* ZIKTransition.h */,
-				CB0BA5ACD913C087B8677657EA94569E /* ZIKTransition.m */,
-				FF29AE10C019BD4873E0DC281AFF75A3 /* ZIKUtil.h */,
-				3F3A21108079A2E1E89C7AF36B8B1DFA /* ZIKUtil.m */,
-				0E49D847E21E5AC6C81050D0864B4486 /* include */,
-				E9D2D53E9E4C60BFDE73E9296C11188A /* src */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		B9E387FAE578EF59D201F2ED8A76BFBC /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				98D45E8B3747E90936E5B2DBC61E1A8B /* Specta.xcconfig */,
-				C30AC3FDD2C139ADCA631E07F6E8FE17 /* Specta-Private.xcconfig */,
-				C8BF96FCAEF5B295961CC7377CDFDE14 /* Specta-dummy.m */,
-				644C22683911EEECE2B3F423D718967F /* Specta-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Specta";
-			sourceTree = "<group>";
-		};
-		CCA510CFBEA2D207524CDA0D73C3B561 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6F6B638A47FF34E7345CDC9C613B5BF5 /* ZettaKit.bundle */,
-				42511B8B3C1E29DB714664F1A8B2DC97 /* libExpecta.a */,
-				32093DC7D4B11A56582CC752D65A9B4E /* libPods-Tests.a */,
-				C5CE33960B44198C4DDC468605A3ADDC /* libPods-ZettaKit.a */,
-				45018390477900ABFD4D22979EBCB816 /* libReactiveCocoa.a */,
-				1B1AC55CD4A61F4881AAFEF03A88E0A8 /* libSocketRocket.a */,
-				BC955D2828EDD99D6C7332F0E44CDE35 /* libSpecta.a */,
-				36A3CB14FC8276F4531C8118B497060B /* libZettaKit.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		D72011D2503E24078D77571F9D079A01 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				6284FE4E702034EE56E2D9D79CA6FF65 /* ReactiveCocoa.xcconfig */,
-				72C0552B5CD20267E4FC7A385C657EF7 /* ReactiveCocoa-Private.xcconfig */,
-				A7822E15A991503A82F5FEE6E582F0BC /* ReactiveCocoa-dummy.m */,
-				D2C4C9B2BF3F297FE3E292FC6123A039 /* ReactiveCocoa-prefix.pch */,
+				45108978875126195B31FE2DFBEBE629 /* ReactiveCocoa.xcconfig */,
+				374914A0326FB605CFF021BA226097A4 /* ReactiveCocoa-dummy.m */,
+				73607478EAE5AC97A9F3D29B6A56B6BE /* ReactiveCocoa-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/ReactiveCocoa";
 			sourceTree = "<group>";
 		};
-		DAEC7FA40AA17357D5F9F4058CE54D4E /* Support Files */ = {
+		B9D416F8505F251C128105B587A691C8 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				7FF34EFBC2A3F53A8864324A5EC966D4 /* ZettaKit.xcconfig */,
-				91392DE38B4FB4739B17385406654308 /* ZettaKit-Private.xcconfig */,
-				C2A2948C50676C32CDBDBD3657A0D7EA /* ZettaKit-dummy.m */,
-				A92B4282F05BE212F5B7A2153BB23407 /* ZettaKit-prefix.pch */,
+				94E72A5AC84C6C7261171D59904427D1 /* CFNetwork.framework */,
+				AA5F9FC346B4E16C3B2AFF9B534E7A86 /* Foundation.framework */,
+				584A2A1EE1548D7617C87D56E67EE011 /* Security.framework */,
+				428B84E579C78098D283602A1DA9F6D7 /* XCTest.framework */,
 			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/ZettaKit";
+			name = iOS;
 			sourceTree = "<group>";
 		};
-		E10F7E980C086EC941E92049790546CD /* Support Files */ = {
+		C25610528C4B39B4D778C081B9B64AA6 /* src */ = {
 			isa = PBXGroup;
 			children = (
-				D4C0894F4912137E58A81C235ABE52F7 /* SocketRocket.xcconfig */,
-				93F2B074CCCBC677B8AC5242D459C20C /* SocketRocket-Private.xcconfig */,
-				3CB800A46024B1C2237C0FC9AC296F8F /* SocketRocket-dummy.m */,
-				E6E9FE5246285877BBD29130C5B9D494 /* SocketRocket-prefix.pch */,
+				2BB5F805E6EE3C8F6F9A4BD84396A798 /* common.h */,
+				5EC40602C388ECBA787A709F0BF646D5 /* compressor.h */,
+				95B78E7EFAC5AA14CB23E9449EDB6D71 /* compressor.m */,
+				537B29BAE46B93F5C1FC44A01BC2D413 /* framer.h */,
+				08E93F192D817B152ED152D748CBF14D /* framer.m */,
+				3E7508F0A9C97F84ED08A362C610BD77 /* ispdy.m */,
+				A9223D9DAAFC739BAF84DCA384433E3B /* loop.h */,
+				1C05DDE8D0DD9249BA9BFB26911B3EC2 /* loop.m */,
+				15E5BA7EC5F92E9A0A10868F417579A1 /* parser.h */,
+				BC093202904054601561F25DA7534E44 /* parser.m */,
+				90592CE8E298086EEA9D8D1CCD214365 /* request.m */,
+				DA297289CB857150CDF7A22C104F02D6 /* scheduler.h */,
+				489B54233C8143CF4A90AC905FBDE827 /* scheduler.m */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		C6D08D37B5DD5FBA33C3B7AB6CFE949C /* Expecta */ = {
+			isa = PBXGroup;
+			children = (
+				5EFED9162BA2F199634F6FF686FB2B9F /* EXPBlockDefinedMatcher.h */,
+				38FAE971B998F0B35182A3F66E41FA1A /* EXPBlockDefinedMatcher.m */,
+				09DA554BAD2666EEEB3875559C732A3D /* EXPDefines.h */,
+				501B3F7AA5171D110E467307574B11CE /* EXPDoubleTuple.h */,
+				2A6F3E9B05DFBFEF1ADC6E414D21600B /* EXPDoubleTuple.m */,
+				03193F0A865EBC01C80201BF200C51E2 /* Expecta.h */,
+				9CD1A380B7532B860A6C0128C7887B36 /* ExpectaObject.h */,
+				A7829E600BBB4A5BA5883A828B9BBBF3 /* ExpectaObject.m */,
+				EC2D6A8C0E1E4016677E28DB6E064CFE /* ExpectaSupport.h */,
+				3C3FDDD4D50E7B52D3730ADD103D1A60 /* ExpectaSupport.m */,
+				31F08478421B679BA6E4224FB47CAABC /* EXPExpect.h */,
+				EE3B50DAF85EAF51CE2D43B130D6ECE3 /* EXPExpect.m */,
+				27DE8DE0E8B6637BA0AF16DD87056317 /* EXPFloatTuple.h */,
+				00D318E89B99D38C5D403C0086512FAB /* EXPFloatTuple.m */,
+				CC94B7B5A389C054C91523F07DE67543 /* EXPMatcher.h */,
+				771858D40C429A9E50FE6C273ED9BCA3 /* EXPMatcherHelpers.h */,
+				5E57C81D7CED70EAC5FCF8435D6CADC0 /* EXPMatcherHelpers.m */,
+				8A5141ABB6A0DD0A189514163370DE5B /* EXPMatchers.h */,
+				451E130E882DA10D9DEFD312555F059B /* EXPMatchers+beCloseTo.h */,
+				D04D8CA58EDFE213709224E5F95FF668 /* EXPMatchers+beCloseTo.m */,
+				7381D6137E81390705BD1F225F55ED8C /* EXPMatchers+beFalsy.h */,
+				08F3CE47921C98C7E3C64DADA02E1FD1 /* EXPMatchers+beFalsy.m */,
+				F2DAF20CA16287BD862139E0D7743366 /* EXPMatchers+beginWith.h */,
+				7BCE3CF1AB18B956FCDAE546831DFED9 /* EXPMatchers+beginWith.m */,
+				07CE79FD9A24A5AE629B23FDB46167AF /* EXPMatchers+beGreaterThan.h */,
+				440035A52587B47DC900191DC2BFC430 /* EXPMatchers+beGreaterThan.m */,
+				244B27FEC7FF1DD9AF0A2F5593A4835D /* EXPMatchers+beGreaterThanOrEqualTo.h */,
+				5E3E923494CC00A096130838B50D4926 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
+				1F60CB0C182EC5AFC1AC0CBF56BCB21A /* EXPMatchers+beIdenticalTo.h */,
+				23AE5BBF485C910CA22290047D3E51B6 /* EXPMatchers+beIdenticalTo.m */,
+				BF9CC99DB0751C60E65BCB260970D6A0 /* EXPMatchers+beInstanceOf.h */,
+				F7C9CE303847B48B98712D44FA8CA097 /* EXPMatchers+beInstanceOf.m */,
+				2D978991DE367B110C9D609D627C6077 /* EXPMatchers+beInTheRangeOf.h */,
+				B7AFF5A1E81FD338B8434B90A6FB86AB /* EXPMatchers+beInTheRangeOf.m */,
+				D910F4A0EDA5C55A84D8370680C81F3D /* EXPMatchers+beKindOf.h */,
+				4DD35D9531E8326FA3C2C171D3194A51 /* EXPMatchers+beKindOf.m */,
+				A4E53D0271C74B39CBC63B4B42151879 /* EXPMatchers+beLessThan.h */,
+				B60BA7C5006EE0F1EF3558CEE92526AB /* EXPMatchers+beLessThan.m */,
+				85680E6ABD2FF8667738D7D965B648DE /* EXPMatchers+beLessThanOrEqualTo.h */,
+				F00FC1BA3B556A2035D50CE2493A93B9 /* EXPMatchers+beLessThanOrEqualTo.m */,
+				8A0585CECF89D799A21C31A5CF61819C /* EXPMatchers+beNil.h */,
+				583D976916D469215A6FADAB0FBDD73B /* EXPMatchers+beNil.m */,
+				08CD6196DA22FBF673CF70E9FE5DB991 /* EXPMatchers+beSubclassOf.h */,
+				E1745B36AEA70DA46E82E11A30A5A1AA /* EXPMatchers+beSubclassOf.m */,
+				974A64EFD437923F338C35D754EF4F14 /* EXPMatchers+beSupersetOf.h */,
+				629F9220AD47D610FB0EDF12B1360A90 /* EXPMatchers+beSupersetOf.m */,
+				A85C90F4299B095EBE7AC5152BA02CAA /* EXPMatchers+beTruthy.h */,
+				74FF21B4E1BFB58DEEABA6E5FA717628 /* EXPMatchers+beTruthy.m */,
+				1F8FE90105F74656A451EEF871EE4711 /* EXPMatchers+conformTo.h */,
+				C3C2081458CBEC4E0C8CBA4FB124389F /* EXPMatchers+conformTo.m */,
+				A537C926D40E7E6F1CBD456E362BDCA6 /* EXPMatchers+contain.h */,
+				B5BBFB976DB961B4EBC3D4CFC38C8953 /* EXPMatchers+contain.m */,
+				2B46B65BA10DB7C108ADBFA93C71A0B5 /* EXPMatchers+endWith.h */,
+				BEB8BD3218534014ECCEBCB5642CC119 /* EXPMatchers+endWith.m */,
+				9A27A1D35EFB8CAC34829886314503F4 /* EXPMatchers+equal.h */,
+				5E8898FC5B43DD1F1C4D4CCB86F47FFB /* EXPMatchers+equal.m */,
+				249F9873EAC3626E09E6E0D7BA246631 /* EXPMatchers+haveCountOf.h */,
+				4FD3117EE1D83C2433A050FAE363A02B /* EXPMatchers+haveCountOf.m */,
+				9C12AB40C0C3AE2A1ED9074978957237 /* EXPMatchers+match.h */,
+				35E1E372DA6F5BF7325EA3EAF2D38748 /* EXPMatchers+match.m */,
+				C921A16385D1282E73FE8B16409CFF93 /* EXPMatchers+postNotification.h */,
+				4399297F896080C94A46270683832A2D /* EXPMatchers+postNotification.m */,
+				DCBEDA66EAE2B416C80E2DA212FC4E51 /* EXPMatchers+raise.h */,
+				EC112ED3538D9B1022DA0CFCD0AFF004 /* EXPMatchers+raise.m */,
+				34330769E5701AA9202A35B2BBDFFE51 /* EXPMatchers+raiseWithReason.h */,
+				C45AF9724992B8B796B18BFF456E45DB /* EXPMatchers+raiseWithReason.m */,
+				C5BC04C23BCF94E8959DFDB04A78D5CF /* EXPMatchers+respondTo.h */,
+				4F5634300B7CB65BBBC645113ED9A7F6 /* EXPMatchers+respondTo.m */,
+				91327C47AC2D5061AC2D328304AC9151 /* EXPUnsupportedObject.h */,
+				E0113159FCF6ECB927AF346ACD793CF2 /* EXPUnsupportedObject.m */,
+				082C0915AB6CDD2D1AAD0DD48BD1A0AF /* NSObject+Expecta.h */,
+				DD122D058273E923AC4EEED3FD82EC39 /* NSValue+Expecta.h */,
+				4803A2B67ED54424ADA2CE58907A1261 /* NSValue+Expecta.m */,
+				0ABE1E4659A526D99789A614791F2A30 /* Support Files */,
+			);
+			path = Expecta;
+			sourceTree = "<group>";
+		};
+		C955D3916E6391B3F184350890C064AB /* SocketRocket */ = {
+			isa = PBXGroup;
+			children = (
+				DB622FA4D3954B9D4C362A81892A87CB /* SRWebSocket.h */,
+				BBA54E8CE2A5CE2CC0876E77600938B9 /* SRWebSocket.m */,
+				CED831C23D270773DD1C609DB35CA7D1 /* Support Files */,
+			);
+			path = SocketRocket;
+			sourceTree = "<group>";
+		};
+		CED831C23D270773DD1C609DB35CA7D1 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				48B82B750F17D002C4520D18CB7F5371 /* SocketRocket.xcconfig */,
+				3A060474D7A11CF8A75C4BABE1F5A6ED /* SocketRocket-dummy.m */,
+				DA33AD5038F62B8DD1AB1EF1778F757C /* SocketRocket-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/SocketRocket";
 			sourceTree = "<group>";
 		};
-		E9D2D53E9E4C60BFDE73E9296C11188A /* src */ = {
+		E5016E84FDB4BCEC51C4E89D1BADB318 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				98201CFB2DAC97ABDEFAA86029E94E29 /* common.h */,
-				E841C2408971FF1DED138C45FD761ABC /* compressor.h */,
-				E46A97013558386BBB9749C6A051D894 /* compressor.m */,
-				6689654F63605798C353AB2168DBDC85 /* framer.h */,
-				3FF6936CE62992A4B9996A0E32768C1E /* framer.m */,
-				0191C029BD1ECA582E02CA24DE4A9D95 /* ispdy.m */,
-				6D0661C7B18B4DC7635DCE7AE6BF2890 /* loop.h */,
-				8C25130F7B870BFFBA45AE7A0CC22D24 /* loop.m */,
-				71D1BE39A7BE68902A951E7C1A15B7DC /* parser.h */,
-				2058EBEE764BEEA8354D1A4D32C972F1 /* parser.m */,
-				A53FA3E439D67AA7931E6A40CDB8CDE0 /* request.m */,
-				02FB0B910927E303746D94038B1EE898 /* scheduler.h */,
-				D29DFB589146C16E787DA8D99C67457B /* scheduler.m */,
+				436062AAFE9AAF30964B59D089249629 /* Classes */,
 			);
-			path = src;
+			path = Pod;
 			sourceTree = "<group>";
 		};
-		ED1C3DB259C65EFF41C79684850E614D /* Specta */ = {
+		E7919C2B5B51C949D3AAD48EB7B41979 /* include */ = {
 			isa = PBXGroup;
 			children = (
-				5FFB1C122FF3CFD89502B26937D763DA /* SPTCallSite.h */,
-				D2BA8B179D4FD25A3BCBAEEB16C676AD /* SPTCallSite.m */,
-				93029730447E84BE07FEF552E631522D /* SPTCompiledExample.h */,
-				CF2DE738F1C28C1D76CCB6C87F9FD17B /* SPTCompiledExample.m */,
-				147E3E9145BBADBD45B55AAA3E000BC0 /* SPTExample.h */,
-				2383BDAEE579F5C80A2BA3B682D038FE /* SPTExample.m */,
-				FC5828955767805377F40939B33EDAC2 /* SPTExampleGroup.h */,
-				766AFBEC903C05FD57DFFD1B16BB5437 /* SPTExampleGroup.m */,
-				4AD3305FF4E3C4746C82AA701E2D9F8F /* SPTExcludeGlobalBeforeAfterEach.h */,
-				4F4158EBD4E8E18F2AF4568A2617E694 /* SPTGlobalBeforeAfterEach.h */,
-				FAFFC9D358DDD39ECB0745FA2023B282 /* SPTSharedExampleGroups.h */,
-				2193B187592F9DE28CB3B599F4C99D86 /* SPTSharedExampleGroups.m */,
-				CA4E32DFF53737F96B4EB48C07C099E1 /* SPTSpec.h */,
-				07514E922FF2FD77D088C58D3EAF7622 /* SPTSpec.m */,
-				7643DDFA6BD4B41C819F0B038A54F9E8 /* SPTTestSuite.h */,
-				C8304142657F82BDB22B7ACDE39B7705 /* SPTTestSuite.m */,
-				DEE96CC83E6023D480F94C8408B016EC /* Specta.h */,
-				4CC318C6BD5F93FB1DDD89B727074DCB /* SpectaDSL.h */,
-				03BAD800091C1652E4E87EFF3E9DC696 /* SpectaDSL.m */,
-				8B96ECB90ACEB9BEEE6A96D1FDD9AD27 /* SpectaTypes.h */,
-				E404DFDD176C035583EE3E27C674F4C2 /* SpectaUtility.h */,
-				A2497882A9E82393DC0DCBF65EE2FDCB /* SpectaUtility.m */,
-				65D3988619FB1D4C6F906990B2633114 /* XCTest+Private.h */,
-				5553608D3E681310854569BC39EA7567 /* XCTestCase+Specta.h */,
-				6FC2080F4068B93C0E233FD81F6BB5DC /* XCTestCase+Specta.m */,
-				B9E387FAE578EF59D201F2ED8A76BFBC /* Support Files */,
+				7DA8C11328E7004806517437231A49AE /* ispdy.h */,
 			);
-			path = Specta;
+			path = include;
 			sourceTree = "<group>";
 		};
-		F03E994872A009065B022476221A4230 /* ReactiveCocoa */ = {
+		F096FA6EC9D558668710C851FE2EBF9D /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				6D8C4DBDF80F0DF40C971FB5B109C837 /* Core */,
-				D72011D2503E24078D77571F9D079A01 /* Support Files */,
-				770BFF60B39DD857360EFBD0B1EFC837 /* UI */,
-				7D84F2B7A4452D2414C8A32573EADEB8 /* no-arc */,
+				47052EA6A6295FBABCD647BB50D38AE3 /* Pods-Tests */,
+				64DA8BF3DEC67EC7C0B2D087F488C6DF /* Pods-ZettaKit */,
 			);
-			path = ReactiveCocoa;
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		F7DD42E5835141AC81D002D262FE3948 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				F77F8C85983D53E4908475A4607D3634 /* ZettaKit.xcconfig */,
+				793A0F5669E52E6DE5E9953A9D1A4C51 /* ZettaKit-dummy.m */,
+				D9CD82B53AF4C7A89CFE08F1166B036C /* ZettaKit-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/ZettaKit";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1C40B99463DCE2A51192965EDC80AED3 /* Headers */ = {
+		317A88106D142F3F1FB1D66BFF76E726 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9EC9186F63D8BA3D2D993F011E2257DE /* SRWebSocket.h in Headers */,
+				AD14E5E364EBF0A6EAA951D8309C94C5 /* Specta.h in Headers */,
+				8E4E1AB8944FF01E54628BCCF179C56D /* SpectaDSL.h in Headers */,
+				816727D4C291781BE28895B1A1513630 /* SpectaTypes.h in Headers */,
+				CBBD909EA888F0172F0B85E392A360F7 /* SpectaUtility.h in Headers */,
+				62360FCFF842D9E73CA08B94F1713FD7 /* SPTCallSite.h in Headers */,
+				FB75139C86866B119A72439090ADED56 /* SPTCompiledExample.h in Headers */,
+				1C73119D787A489A0AB801F59E7BA91B /* SPTExample.h in Headers */,
+				D1CC4522173639482DE73AF66EB73E44 /* SPTExampleGroup.h in Headers */,
+				DDCFC6EFB7D833E758BD8EA08A79B91D /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
+				6111D55178BA9CA2C0418F0549A79CE5 /* SPTGlobalBeforeAfterEach.h in Headers */,
+				C8AEEE05730CC62F5F4FA27A7ACE2008 /* SPTSharedExampleGroups.h in Headers */,
+				1666E3FDB1EBAD4A6608D4DD8D75B7C0 /* SPTSpec.h in Headers */,
+				93B0663A8A755A0D376F8BD624779B51 /* SPTTestSuite.h in Headers */,
+				F7E4A95706FF37D165A5C1AB605CAC52 /* XCTest+Private.h in Headers */,
+				34D133B0E80038C70F6FB3043924FC90 /* XCTestCase+Specta.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1DD715C561572FC13B66C4C40D077FDF /* Headers */ = {
+		8C77439302755F490BE83B48ED105DDC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A93DB90E0361D24EACAAC918DFF2462 /* SPTCallSite.h in Headers */,
-				9DEA3D740E24D640765F756BCA825478 /* SPTCompiledExample.h in Headers */,
-				D7EB04C3267DA586AE90CFE7B0D45C14 /* SPTExample.h in Headers */,
-				6777AFC696F34BE679C862942C8C921B /* SPTExampleGroup.h in Headers */,
-				4C0B5F76B7CAD31B6859C62C5708FD72 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
-				A90D195405682FE62B855C1AE68E80CC /* SPTGlobalBeforeAfterEach.h in Headers */,
-				101F7083ECF2A6744C851F5F00F685EB /* SPTSharedExampleGroups.h in Headers */,
-				6988F33B73C2924C8C765387399D41BC /* SPTSpec.h in Headers */,
-				08F92B755B99B0B3CA61D9E5CE1D5C6F /* SPTTestSuite.h in Headers */,
-				67204AB43957605094FDC910740FC892 /* Specta.h in Headers */,
-				F3C743B8A764F65E3E983268F82781ED /* SpectaDSL.h in Headers */,
-				4F589254367F6C974F110B3EEA264909 /* SpectaTypes.h in Headers */,
-				B23B2316C687E70EB5429EB11C485022 /* SpectaUtility.h in Headers */,
-				451FD622A5348A27FEC27AFD155BF0AB /* XCTest+Private.h in Headers */,
-				90D140E4C4AB174D1FF089507D1D252F /* XCTestCase+Specta.h in Headers */,
+				EACFAFCC8171D402794171BDA96E6B32 /* SRWebSocket.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		52D5529431ED321ACEB869604EFB5EC7 /* Headers */ = {
+		AC9CE58A03D683A84002DD9FE87D996B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C127E0D2CDAFE97C0841AF292B39C97E /* ZIKDevice.h in Headers */,
-				E12D46FEA6B1634FE67C73E5E64AE320 /* ZIKLink.h in Headers */,
-				C97274A2EBD04024761E9F4526C81AC6 /* ZIKLogStreamEntry.h in Headers */,
-				4516E3DC4629B4277C38C9CB9AAF28CD /* ZIKMultiplexStreamEntry.h in Headers */,
-				A5651594EC1B0111A8433B4DAE5958A2 /* ZIKPubSubBroker.h in Headers */,
-				D35A0ED585D2B12CB6E6805C8F7ED9CB /* ZIKQuery.h in Headers */,
-				ADFA5655A3BE3F3A29DF18F3D204CB41 /* ZIKRoot.h in Headers */,
-				72134CEB6FD22455BB445072C8AF8A2C /* ZIKServer.h in Headers */,
-				09E7208829DB5BA8F397AB171B825C9F /* ZIKSession.h in Headers */,
-				7CDBF7E64AEDADCEE3D494E7B9085B94 /* ZIKSpdyDelegate.h in Headers */,
-				730AE7622E26C1F20305098A1AEE7D19 /* ZIKStream.h in Headers */,
-				97AC67AEF9570BE0E11F5A130E3DFA10 /* ZIKStreamEntry.h in Headers */,
-				CD31B164A246331196D92C70F2163A19 /* ZIKTransition.h in Headers */,
-				7B011BCB282C6AD41F83458851CB454B /* ZIKUtil.h in Headers */,
-				1EA80C447F5DAFFD4E35731658A4460E /* common.h in Headers */,
-				DF4C241BB0AC02B3360A1B6F64150C94 /* compressor.h in Headers */,
-				DA2CA26AC8F0CE550F56D47E222811B8 /* framer.h in Headers */,
-				20EE780E8EEFBB03591209C50AEBD085 /* ispdy.h in Headers */,
-				378E0082380C5CEC38BD4D041E9730B7 /* loop.h in Headers */,
-				96254770A5E1A6986543D44A42321170 /* parser.h in Headers */,
-				F7D1DB7410D4C4ABAE010D7EB58CE086 /* scheduler.h in Headers */,
+				8BFA22E78C0B21D091CC85D76779FF88 /* common.h in Headers */,
+				26FD3C7E654D1F934C6DA2E1A47AC743 /* compressor.h in Headers */,
+				594FF15A9A88844A7D2A4301179EC719 /* framer.h in Headers */,
+				5C424E6B9AA0BCD4C6A32A4A48876EB0 /* ispdy.h in Headers */,
+				EF3BBF2B2591678A29D12387F238F28D /* loop.h in Headers */,
+				40C9CB0769F21639775AD63B83C55A84 /* parser.h in Headers */,
+				0E0D7DCE4D1E6FF5C7B46AE7B7EA1B73 /* scheduler.h in Headers */,
+				7F550437AC1E890B01FCD43EFC962F77 /* ZIKDevice.h in Headers */,
+				0C24DC9290CE12BA4911554A3A27D489 /* ZIKLink.h in Headers */,
+				706AFF72C83746CE8078DCF8E57BE1AF /* ZIKLogStreamEntry.h in Headers */,
+				D27B4B68B850F23601D68A164BAE1D50 /* ZIKMultiplexStreamEntry.h in Headers */,
+				21FCF58D3ACF7E44F499A0B545363182 /* ZIKPubSubBroker.h in Headers */,
+				F056B1BF6DD0CA8F876AA8EB9FD41D3F /* ZIKQuery.h in Headers */,
+				1816E2693F144D3CC28D229819850927 /* ZIKQueryResponse.h in Headers */,
+				7DD14CC7F97E07B8C3C16F4F24C8C561 /* ZIKRoot.h in Headers */,
+				BB71013946E3F49F35680565F0E0331E /* ZIKServer.h in Headers */,
+				CD2D6E315BBB7AB19D357545ABAAD9B5 /* ZIKSession.h in Headers */,
+				4E283215B682D67972E9267559EB0750 /* ZIKSpdyDelegate.h in Headers */,
+				9B7D74C5C8BCBE47856A23547CAF4775 /* ZIKStream.h in Headers */,
+				337569619D6A4D1973D69E12D8504EF1 /* ZIKStreamEntry.h in Headers */,
+				FAF3834F85CA85CF81C799070D100D9B /* ZIKTransition.h in Headers */,
+				58C9D0ED39EB8B217D58BF637FD29E05 /* ZIKUtil.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D1094359261984DF84AF9B72CCD084E4 /* Headers */ = {
+		B3D495894DF40839465A2B44655D6C1E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				429F18B8BE3A1C08767A2F60E79C4C50 /* NSArray+RACSequenceAdditions.h in Headers */,
-				3A0F6CE2B333BA7C0250FD8C043FC5BD /* NSData+RACSupport.h in Headers */,
-				66487DE5A3045D4D2E2195D7B41D5E8B /* NSDictionary+RACSequenceAdditions.h in Headers */,
-				632F3FFF9F853CEB1AEBAE5221F1DC74 /* NSEnumerator+RACSequenceAdditions.h in Headers */,
-				D3C4E5383F87710DCE68B40FAE69D191 /* NSFileHandle+RACSupport.h in Headers */,
-				0C2C1835A2B120D3A15A51202AF1D9A9 /* NSIndexSet+RACSequenceAdditions.h in Headers */,
-				04718F295655A0278A8C6E59E3B73400 /* NSInvocation+RACTypeParsing.h in Headers */,
-				7B77A0741056810E7AFD0404A1102E42 /* NSNotificationCenter+RACSupport.h in Headers */,
-				C1142B3887048C11E3AE76291711001C /* NSObject+RACDeallocating.h in Headers */,
-				B1632E75D7D3D3B2A8F4FDD50EF5C915 /* NSObject+RACDescription.h in Headers */,
-				95DA33E52A0C0194E013EDEEAE6E2D06 /* NSObject+RACKVOWrapper.h in Headers */,
-				4D2B985C52560B3CA9C1176A13E3796D /* NSObject+RACLifting.h in Headers */,
-				98015E4C2BFF8B596C6E6948F1707ED0 /* NSObject+RACPropertySubscribing.h in Headers */,
-				62476B05C2D6B24F4F597D30E1E7B2DE /* NSObject+RACSelectorSignal.h in Headers */,
-				C2C4D5979CE32C0648256B97BE154D59 /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
-				2FB3F8B188F8432E07F3902EDAA6D18A /* NSSet+RACSequenceAdditions.h in Headers */,
-				EA1840D44BAACF682563B6A69821AAE9 /* NSString+RACKeyPathUtilities.h in Headers */,
-				6F5353645F7884E1411DDFA99554990F /* NSString+RACSequenceAdditions.h in Headers */,
-				CFAFB58A6A385246F39AAEBB3D0EF67B /* NSString+RACSupport.h in Headers */,
-				D1CF2CDDB9ABDC0D04CAC59237496563 /* NSURLConnection+RACSupport.h in Headers */,
-				A745CCC4FBB3CE81A397FC6E30079261 /* NSUserDefaults+RACSupport.h in Headers */,
-				5BCB4A3ED72376C99C2AEA2D3F50141E /* RACArraySequence.h in Headers */,
-				9499F9FDEA003A2FB4A33670ADA650AF /* RACBacktrace.h in Headers */,
-				C372414F808CB17ACCCBD00F2601CF1B /* RACBehaviorSubject.h in Headers */,
-				D4851D2DB0ABEC3DD339126DE788A2BE /* RACBlockTrampoline.h in Headers */,
-				2DC1FCB58E4E547A30E96286BFFEE7D8 /* RACChannel.h in Headers */,
-				51C424CAB7AAF472D6FDE56195A6D140 /* RACCommand.h in Headers */,
-				CE3710E77A2905E64DA3B708D0429AB5 /* RACCompoundDisposable.h in Headers */,
-				E9A7D9E97917D57744F1C8365D77D154 /* RACDelegateProxy.h in Headers */,
-				86F297AFDEE13C7A2B7E195E980B678D /* RACDisposable.h in Headers */,
-				0FC3A4AD97631071FDCDE43B2B5C6D26 /* RACDynamicSequence.h in Headers */,
-				CDA765AB7544DDABA28C3B207917DF35 /* RACDynamicSignal.h in Headers */,
-				11B0BA4F75850B3BCAC8D653DF3D914B /* RACEXTKeyPathCoding.h in Headers */,
-				FE93D7EC9C3C7F35422052B2310C755E /* RACEXTRuntimeExtensions.h in Headers */,
-				ACC38020DDB485B1BB0C4CC358F78B10 /* RACEXTScope.h in Headers */,
-				056E7B1F79E16501396D1C9ADE0EAF7B /* RACEagerSequence.h in Headers */,
-				2E4FE91FC73AB8BE1CC35135A569E81D /* RACEmptySequence.h in Headers */,
-				2F182D3D3A130E372170287B97E60503 /* RACEmptySignal.h in Headers */,
-				B8F7FBBA1AE11BF755D655D3EF7E763F /* RACErrorSignal.h in Headers */,
-				0621DE66B38960776582FB32C4D463B6 /* RACEvent.h in Headers */,
-				85735B9DBB1A98626A45E6D72E0B9B75 /* RACGroupedSignal.h in Headers */,
-				87F5AF0D77C560173C3254A5C76C1156 /* RACImmediateScheduler.h in Headers */,
-				33A049056B8E6A425DA670B1F6652226 /* RACIndexSetSequence.h in Headers */,
-				557B8ABB9717CD859C812F05069E237C /* RACKVOChannel.h in Headers */,
-				1CFEEBCCC6DBB7C9D53EBAD7D93F6847 /* RACKVOProxy.h in Headers */,
-				2FD5EAF1339873938E1A110A9F3C55EC /* RACKVOTrampoline.h in Headers */,
-				14477A8973DCABC6755CFF7379125835 /* RACMulticastConnection+Private.h in Headers */,
-				4F7EB693C0124C67E778E5D7C55F5903 /* RACMulticastConnection.h in Headers */,
-				A000D37CEECF04A0566AC0FC4BC005A4 /* RACObjCRuntime.h in Headers */,
-				ACB4F3E7711FE4B2E19600BB36ABB1AD /* RACPassthroughSubscriber.h in Headers */,
-				55BDDC141C2412005DA247EC36417B82 /* RACQueueScheduler+Subclass.h in Headers */,
-				853F7B81E1945B0215C76BAA92BB4A55 /* RACQueueScheduler.h in Headers */,
-				7341FB6CD51299C098677C59F9190A96 /* RACReplaySubject.h in Headers */,
-				F869F60FF663BBB8F588727C64C5B320 /* RACReturnSignal.h in Headers */,
-				8FDE97508FF26BD3BBE204A497CE9C7E /* RACScheduler+Private.h in Headers */,
-				5DA28102AEE14A4622B8BB50F99F5A04 /* RACScheduler+Subclass.h in Headers */,
-				F3BF232F14D17033B521E907EC1B3A58 /* RACScheduler.h in Headers */,
-				74C145F9F54F16EC8A2C7B00F5383DCF /* RACScopedDisposable.h in Headers */,
-				50904F7BB3386F63B0770F1D705E25E5 /* RACSequence.h in Headers */,
-				06BEB646C557CC34E8A16F291ACA810E /* RACSerialDisposable.h in Headers */,
-				D75CE78CE7CC7F2942CE8D9A706E3777 /* RACSignal+Operations.h in Headers */,
-				FCA4D5001730886A592D4FED121DD86C /* RACSignal.h in Headers */,
-				7543FC0118AA7C066C74CAF7915FDAE2 /* RACSignalSequence.h in Headers */,
-				64D3DD6BB9FE96B0A165C4C77496C5EB /* RACStream+Private.h in Headers */,
-				D978BBA9B0BA6153B3FA7FE4D24006B1 /* RACStream.h in Headers */,
-				B4292F4254BE0AEC3FB70C6BA2512188 /* RACStringSequence.h in Headers */,
-				28E5C463884ADD47DDC46200B4AE823D /* RACSubject.h in Headers */,
-				EF9FB139B34F12F9443C7C281038874D /* RACSubscriber+Private.h in Headers */,
-				35D6F88642BB4B314883E6E6076271F0 /* RACSubscriber.h in Headers */,
-				73E42B7BB6A86B2ABE123CC9FA207322 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
-				20366BD9C01C9115B898E2DCCD47634D /* RACSubscriptionScheduler.h in Headers */,
-				16CDC87CE671B28A6D8F0890E4796840 /* RACTargetQueueScheduler.h in Headers */,
-				B693EF8A744DD2FB2FB6473C34CDADE7 /* RACTestScheduler.h in Headers */,
-				3D43B18EB1701601BB434174C2FF6540 /* RACTuple.h in Headers */,
-				05BFDFBAC5EF92C6ABC26480C528B057 /* RACTupleSequence.h in Headers */,
-				390BD86E1B6B5E140017B0D5E6697086 /* RACUnarySequence.h in Headers */,
-				7BFB95A70E54DBED0CBC911D9BCE7AA7 /* RACUnit.h in Headers */,
-				804788542E20265849CFE1E5B13197E3 /* RACValueTransformer.h in Headers */,
-				6AE121A8DC66DEDB7D155D70E77DA38D /* RACmetamacros.h in Headers */,
-				160EE3E96F342A127BBFB482F4A8179A /* ReactiveCocoa.h in Headers */,
-				F5D10C746FA04467584A8109DD2B4E1C /* UIActionSheet+RACSignalSupport.h in Headers */,
-				F419EFB5C4B6877B03785CCD18C65C87 /* UIAlertView+RACSignalSupport.h in Headers */,
-				F2B010FE0A5AF96C02BF791805794691 /* UIBarButtonItem+RACCommandSupport.h in Headers */,
-				21A9501DA541FA525DB626B32AAACC13 /* UIButton+RACCommandSupport.h in Headers */,
-				8C16389598BFB5133687A00192FFD3E9 /* UICollectionReusableView+RACSignalSupport.h in Headers */,
-				072318F89C37CFDEF19476152B3CAF24 /* UIControl+RACSignalSupport.h in Headers */,
-				9BDD9B5C0123A65FD597FF85712762B5 /* UIControl+RACSignalSupportPrivate.h in Headers */,
-				467EC80D015528A50A394879FC005312 /* UIDatePicker+RACSignalSupport.h in Headers */,
-				7FE619BD3F4B1CD8A163A8BCEE1ACB08 /* UIGestureRecognizer+RACSignalSupport.h in Headers */,
-				23F6694D7C400F694742D29B52E5E025 /* UIImagePickerController+RACSignalSupport.h in Headers */,
-				4DE5DBBE43F6F260C18733927EB440E7 /* UIRefreshControl+RACCommandSupport.h in Headers */,
-				508FCBD0D73CA33A6FEBF8D299DB2E62 /* UISegmentedControl+RACSignalSupport.h in Headers */,
-				6E21218B0ED0312F4DBCF360470608C6 /* UISlider+RACSignalSupport.h in Headers */,
-				777CA6F4A9FBE830D235E6408A55F8EC /* UIStepper+RACSignalSupport.h in Headers */,
-				908C06745098D7AF7860282B9365C723 /* UISwitch+RACSignalSupport.h in Headers */,
-				BB140B384F40D654C2E01C5D8D408EE5 /* UITableViewCell+RACSignalSupport.h in Headers */,
-				69712687D2092164B02CACA7DAB46280 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */,
-				52B6700CF02DB3B32EAD262C8FE514BD /* UITextField+RACSignalSupport.h in Headers */,
-				AD2B2C387666F13D2DA4E834377EC4BB /* UITextView+RACSignalSupport.h in Headers */,
+				FCA9BAF8CF708718EC503C38708AD0B9 /* NSArray+RACSequenceAdditions.h in Headers */,
+				33CD761C58B632A4D460232C6DE3BF81 /* NSData+RACSupport.h in Headers */,
+				0B4080F96E0B5E1FC475BBD05878A8EC /* NSDictionary+RACSequenceAdditions.h in Headers */,
+				E15BB51E6D9F6834DD5E7762243C8E1E /* NSEnumerator+RACSequenceAdditions.h in Headers */,
+				209D9F8F438C5BCAE43A8DACE4BBBC22 /* NSFileHandle+RACSupport.h in Headers */,
+				3CE3B0E3217BD64C24CCC1111C6C5097 /* NSIndexSet+RACSequenceAdditions.h in Headers */,
+				332BF7624937AE31CFC65DCCA3A72B12 /* NSInvocation+RACTypeParsing.h in Headers */,
+				DD57EBD90B0BBFCC7E6D8FC007AE1A05 /* NSNotificationCenter+RACSupport.h in Headers */,
+				AC06F361ACA58CDEC16B4C666E4238D0 /* NSObject+RACDeallocating.h in Headers */,
+				D14C9295D900EEF68C2C6A46AF17DD7F /* NSObject+RACDescription.h in Headers */,
+				F3F415BDCAE1690166333A8A258D4E82 /* NSObject+RACKVOWrapper.h in Headers */,
+				1FD377AB3494FCDDA57D13834C37F9B1 /* NSObject+RACLifting.h in Headers */,
+				797E71F721305E25ECE022AF2EB16925 /* NSObject+RACPropertySubscribing.h in Headers */,
+				28AF905C86178E5839C21E9D8C565044 /* NSObject+RACSelectorSignal.h in Headers */,
+				18E8E38EA6FE207F73B28DCB4C2E205F /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
+				FF68A09176DB8794E418CD80B8AEE20D /* NSSet+RACSequenceAdditions.h in Headers */,
+				63D9155454E68888987DCC54A8D7ED01 /* NSString+RACKeyPathUtilities.h in Headers */,
+				7537CBD4D00339DC964517785E52046D /* NSString+RACSequenceAdditions.h in Headers */,
+				86DEC65F69CA7A9EDCE07A396E8463A7 /* NSString+RACSupport.h in Headers */,
+				0FE5EC7315C8E0F9102DA446851CFE1E /* NSURLConnection+RACSupport.h in Headers */,
+				32FF5CFF84A6A82A04381934613814F8 /* NSUserDefaults+RACSupport.h in Headers */,
+				7B76061E0ED323432A88EC4322A27464 /* RACArraySequence.h in Headers */,
+				AC6D16F5571EB62AE57B294234124C71 /* RACBacktrace.h in Headers */,
+				13D64B16106AA4EDBFA0AB729A56D3BD /* RACBehaviorSubject.h in Headers */,
+				99AFB589293DE00826E08212E67BE9EC /* RACBlockTrampoline.h in Headers */,
+				A206C79A89B961A3497AC97A45046548 /* RACChannel.h in Headers */,
+				D3E3068562B2235BC6453DC38B4EEC7B /* RACCommand.h in Headers */,
+				6426A3440967FD3FE00EE3D45DAAEACC /* RACCompoundDisposable.h in Headers */,
+				28495910C7FBDBE1015E38A35AAE7FA1 /* RACDelegateProxy.h in Headers */,
+				1A238138E6A38258F981090B769D1DB7 /* RACDisposable.h in Headers */,
+				B89A6BEF0EAB11CC945337042434B532 /* RACDynamicSequence.h in Headers */,
+				0E38DC5F1935686AB6B99ECA1E87EF3B /* RACDynamicSignal.h in Headers */,
+				80139AF056C3EFA1DAF8587D55639B4C /* RACEagerSequence.h in Headers */,
+				8B52A2BEE079E0A1EEC91C6D6C568837 /* RACEmptySequence.h in Headers */,
+				A99E2451E77F4FD058B409887CAD28AE /* RACEmptySignal.h in Headers */,
+				A5696F6D6A65B913C0576C508723F464 /* RACErrorSignal.h in Headers */,
+				867CCF41E1A21E4D66FAA17AF58A158D /* RACEvent.h in Headers */,
+				8FB1873754FC4FC0F99AAA31B678B4C1 /* RACEXTKeyPathCoding.h in Headers */,
+				58CAE9CA550EAD45A5E1858CCE07EB46 /* RACEXTRuntimeExtensions.h in Headers */,
+				5BF3BBBA546C806349C163EE0BA34154 /* RACEXTScope.h in Headers */,
+				668EAA1991EF86669F419C4CA7817921 /* RACGroupedSignal.h in Headers */,
+				454C8D24CD284E983BA4F6178E1C592B /* RACImmediateScheduler.h in Headers */,
+				48DCFB9A3439974027B2ADD98064E147 /* RACIndexSetSequence.h in Headers */,
+				017AB6018C3D9D8BB6B26D6505E9885D /* RACKVOChannel.h in Headers */,
+				2F643572309EC1DA20C19A672DC2D486 /* RACKVOProxy.h in Headers */,
+				873BA3D71241B46B6B80B6586B4B48BF /* RACKVOTrampoline.h in Headers */,
+				6AB877F558569CB7B23DDCDB4AE48CA2 /* RACmetamacros.h in Headers */,
+				4FBF816B10502E1FEB94E72CCED27611 /* RACMulticastConnection+Private.h in Headers */,
+				103E5A84964DD623050FF28586AA40CD /* RACMulticastConnection.h in Headers */,
+				0A13836F567DEBD532C377D098B09FA4 /* RACObjCRuntime.h in Headers */,
+				981252E61DAAE4130C882D5027950F07 /* RACPassthroughSubscriber.h in Headers */,
+				7833659CFEDE82D96D3C1EFAF43D3726 /* RACQueueScheduler+Subclass.h in Headers */,
+				3F774AC45C580EBF35959B2F66328351 /* RACQueueScheduler.h in Headers */,
+				7AF513C2EE0C3F942A8C3583CC1E9E3F /* RACReplaySubject.h in Headers */,
+				B4D3B8EC0B76DE2F99C27186F94D830A /* RACReturnSignal.h in Headers */,
+				48FF6CD26B33E6D07AB3D96B304BC5B8 /* RACScheduler+Private.h in Headers */,
+				5B3A877EF264E6FA602FE408AD940FBB /* RACScheduler+Subclass.h in Headers */,
+				BF933D54645AEEBB5D9B9898F4090AA2 /* RACScheduler.h in Headers */,
+				2C5D27D3BE2B20C5950B34620043FD6E /* RACScopedDisposable.h in Headers */,
+				41C1F41A597FD9B0CEDA3DDA43DC91CC /* RACSequence.h in Headers */,
+				F7E0022943AC595A7CCD87C665064B73 /* RACSerialDisposable.h in Headers */,
+				484AE62683CEE1354AC53E85EE20F086 /* RACSignal+Operations.h in Headers */,
+				539F1A118B2C8A2D2051E14EFD483266 /* RACSignal.h in Headers */,
+				617734CFB46F07A85813365ED3F84E36 /* RACSignalSequence.h in Headers */,
+				D3C67933C1FCEED135999EDEE8141798 /* RACStream+Private.h in Headers */,
+				B80B82D1B951E4337F43E9A24DEF10B7 /* RACStream.h in Headers */,
+				F02A759238E0EFEC5306270AD75F2F30 /* RACStringSequence.h in Headers */,
+				22598CDA63782A73F97254E333F9EA47 /* RACSubject.h in Headers */,
+				86A21DEE9BB2F93B78E455B41EC0C100 /* RACSubscriber+Private.h in Headers */,
+				FD8DD4D5F90C499ACF28ABAB3CF346A7 /* RACSubscriber.h in Headers */,
+				CAA01881F44EF97CA7080EE4CE991803 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
+				B27D35C3718F619B94F5386C72FDDCC5 /* RACSubscriptionScheduler.h in Headers */,
+				0B5B1FEB06F5C4B4F8EFED45CE1CEC62 /* RACTargetQueueScheduler.h in Headers */,
+				698934DD487D9CDA6350C3834E94B6D2 /* RACTestScheduler.h in Headers */,
+				A3818B2C6C0B4A1A97E1FD13619238EE /* RACTuple.h in Headers */,
+				98BFCA3BAAB97B5C65A0334F6768AF58 /* RACTupleSequence.h in Headers */,
+				2035B32370B94F299363AB8D2E6D72A5 /* RACUnarySequence.h in Headers */,
+				891FC9F5C703C1972351A9C680823738 /* RACUnit.h in Headers */,
+				EB8AC483B4160EC60604FAA21FFE4778 /* RACValueTransformer.h in Headers */,
+				85607D78C803828DD824D339B53F9F65 /* ReactiveCocoa.h in Headers */,
+				EED1ECA163F48E1E59FC80EABCFFE37E /* UIActionSheet+RACSignalSupport.h in Headers */,
+				62185A59C2F64AB15D20BCC0AE6C065A /* UIAlertView+RACSignalSupport.h in Headers */,
+				843A633D759AF5A8C9E8A27D4B82CE6F /* UIBarButtonItem+RACCommandSupport.h in Headers */,
+				3F0B5F045FD25D9F011C509EC67C8A07 /* UIButton+RACCommandSupport.h in Headers */,
+				2A0184A78F3C7D7B2BD775036E574087 /* UICollectionReusableView+RACSignalSupport.h in Headers */,
+				C01997BA0634D6A23EBC22ABCDF32B52 /* UIControl+RACSignalSupport.h in Headers */,
+				CC2BA9C7F1B9DCB4949049B82E78C685 /* UIControl+RACSignalSupportPrivate.h in Headers */,
+				CE560DC6FF3DC7FEEEAA48F1BED35A43 /* UIDatePicker+RACSignalSupport.h in Headers */,
+				9EED295B9A802E1E538352864C06B076 /* UIGestureRecognizer+RACSignalSupport.h in Headers */,
+				E35422EC13D1B1FF09C12375029AFEDE /* UIImagePickerController+RACSignalSupport.h in Headers */,
+				61732C1B868F27ECC7FA129996FF4283 /* UIRefreshControl+RACCommandSupport.h in Headers */,
+				4792EF718E0EE4760F759548B92426BB /* UISegmentedControl+RACSignalSupport.h in Headers */,
+				6E43B327A364A177C2F1C82E4BF1E574 /* UISlider+RACSignalSupport.h in Headers */,
+				C99233CEEC3FA82B7EE8DD644266221D /* UIStepper+RACSignalSupport.h in Headers */,
+				51E0A9299B669D80E948292EF7E909CC /* UISwitch+RACSignalSupport.h in Headers */,
+				D19DD5995143EB8D46F5DF78942A03EB /* UITableViewCell+RACSignalSupport.h in Headers */,
+				5FE8785938407DA6CAA2AE8B559BAD84 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */,
+				987AFB493C7CA3FFC13970122FECDB9F /* UITextField+RACSignalSupport.h in Headers */,
+				B40288245A9C8CC8134DC95B3C30FFB4 /* UITextView+RACSignalSupport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EBBF84533DDBF3718D9D82A5D12029F9 /* Headers */ = {
+		C6AD7852D34E8A80DFF3B8376BDE812F /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F583639A447D0279113154A03ADDA54A /* EXPBlockDefinedMatcher.h in Headers */,
-				6B157BC77CF353C552F3902798138506 /* EXPDefines.h in Headers */,
-				CAAE9BED08C1AE6605F9BA007DBC7D55 /* EXPDoubleTuple.h in Headers */,
-				47B371BED3C685BCEAA549B8EA97F594 /* EXPExpect.h in Headers */,
-				1EBEA01019D07EBCE9E34E91AF48ABE4 /* EXPFloatTuple.h in Headers */,
-				1D9DAD5C6CD32D5EC97E2F38B106744C /* EXPMatcher.h in Headers */,
-				1AB87CAF2E83E599E4C8E1DA1EC18951 /* EXPMatcherHelpers.h in Headers */,
-				E28950269076D4C7BE7F03F3768F0508 /* EXPMatchers+beCloseTo.h in Headers */,
-				CB17BB41BEC9C9663886E3479F2CF651 /* EXPMatchers+beFalsy.h in Headers */,
-				1CDB291ABBA51C25F58AB49510C2AF76 /* EXPMatchers+beGreaterThan.h in Headers */,
-				26B91942637CC1ECC50BF24DB3397FD4 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */,
-				3A6D61358792004C59225A190EDACB11 /* EXPMatchers+beIdenticalTo.h in Headers */,
-				E2D4D8F463466B95AD64F081F874BF6B /* EXPMatchers+beInTheRangeOf.h in Headers */,
-				215022D167A029BA1387F044D5BB8068 /* EXPMatchers+beInstanceOf.h in Headers */,
-				9631D62FE3494E1814BE6CAA64215516 /* EXPMatchers+beKindOf.h in Headers */,
-				D04AC40E5BDBC583E2F24D07229DC1C6 /* EXPMatchers+beLessThan.h in Headers */,
-				5DEEADC22BCFFCB48888EB2A40E5EFC4 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */,
-				D9E725B077E4EE39D1F2699052F26AD1 /* EXPMatchers+beNil.h in Headers */,
-				4A8A904C19CA595542F745713A304E44 /* EXPMatchers+beSubclassOf.h in Headers */,
-				985FB534AAFB396E4B51428F25C3EDD8 /* EXPMatchers+beSupersetOf.h in Headers */,
-				9ACFAF6CDBBFC38FFCD4A279B6329491 /* EXPMatchers+beTruthy.h in Headers */,
-				06AB0B63B184835D4451033CC22A7BBB /* EXPMatchers+beginWith.h in Headers */,
-				24775FEC384469772A3215FB4003DBB9 /* EXPMatchers+conformTo.h in Headers */,
-				D7D9C177BAA333422295E078C9EA5F17 /* EXPMatchers+contain.h in Headers */,
-				91F30950A838A3C253E64551B29AF177 /* EXPMatchers+endWith.h in Headers */,
-				3FE80602458E3658ACDC02672228B79D /* EXPMatchers+equal.h in Headers */,
-				887B38FF249355B3B743798C9EC5615E /* EXPMatchers+haveCountOf.h in Headers */,
-				5BE14ADB6F0CD688931AD7E281D8846D /* EXPMatchers+match.h in Headers */,
-				542C1CFC25DD237F0AF837A829485898 /* EXPMatchers+postNotification.h in Headers */,
-				0C0E4E87FC9BA5EC78F72E3B11C13A85 /* EXPMatchers+raise.h in Headers */,
-				BC5CD40866692F6DD88AAEC6DE99B51B /* EXPMatchers+raiseWithReason.h in Headers */,
-				581761AA776A29844071E0A36D53CDD0 /* EXPMatchers+respondTo.h in Headers */,
-				54F7826640E56F5232E10F4F64D08DA3 /* EXPMatchers.h in Headers */,
-				8C263912AFCDE7BFB6295AEA8DDEC8CD /* EXPUnsupportedObject.h in Headers */,
-				EA8A7F438C826291ADA050204743CB52 /* Expecta.h in Headers */,
-				0D3FBB36339ACBAAB8DD646A43FB320C /* ExpectaObject.h in Headers */,
-				3615E83769FE794AE868D5E56B628853 /* ExpectaSupport.h in Headers */,
-				7C85F632BF7E4E94D331B57D2841BCD1 /* NSObject+Expecta.h in Headers */,
-				0D2862C43C2492E2167732E737B20236 /* NSValue+Expecta.h in Headers */,
+				8DF90D623F7F9015EEE9F1D7FEE7E053 /* EXPBlockDefinedMatcher.h in Headers */,
+				6A4E3ACA285A21392936C110E7EC91F0 /* EXPDefines.h in Headers */,
+				3A013F13122CDB8EE962F8CB7C6FCC8E /* EXPDoubleTuple.h in Headers */,
+				A6854D311D55E2BBD8BFCE4E82DF3EA9 /* Expecta.h in Headers */,
+				081F2104425CDCB0915354E2FBD7E24E /* ExpectaObject.h in Headers */,
+				7AC91F55DAAA2F0223A97BEFF8BCAF68 /* ExpectaSupport.h in Headers */,
+				2A17721E4A81DB608CA6D4FB6F0ADAFB /* EXPExpect.h in Headers */,
+				341D7536159B52F41598F730CC45D548 /* EXPFloatTuple.h in Headers */,
+				07282695806D1DFBF187BFA004D80641 /* EXPMatcher.h in Headers */,
+				A8490A46CB5206BCA5F90FCFBA2D731E /* EXPMatcherHelpers.h in Headers */,
+				AA7B402D31D86AE5E3DD083408311FF1 /* EXPMatchers+beCloseTo.h in Headers */,
+				F4CA468B5A9F8FF2A4DB8B236A8E71BF /* EXPMatchers+beFalsy.h in Headers */,
+				021C50274FF43A6F07E119D572C3ACB6 /* EXPMatchers+beginWith.h in Headers */,
+				8F674582EE71972EE60EFD96C1F173D5 /* EXPMatchers+beGreaterThan.h in Headers */,
+				3E463E2B6917D9AA08A03BA8A8E74A18 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */,
+				AB1D6408D48F6ECF3FCE553BE73961F5 /* EXPMatchers+beIdenticalTo.h in Headers */,
+				D42799488F38F2DB8A580730CEE13CE6 /* EXPMatchers+beInstanceOf.h in Headers */,
+				97E91EC237B8623D895DBF6092034AD7 /* EXPMatchers+beInTheRangeOf.h in Headers */,
+				9B546D0F895D9B5A8316B948CEE95C77 /* EXPMatchers+beKindOf.h in Headers */,
+				DFF580AE359407E841BA8D8DDCE6E299 /* EXPMatchers+beLessThan.h in Headers */,
+				EE52A320EC3155B114104E06396D1B59 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */,
+				74707D5ABEC55B3084F52C40A4227B06 /* EXPMatchers+beNil.h in Headers */,
+				14C609D8F203FD45194E93997EFF744E /* EXPMatchers+beSubclassOf.h in Headers */,
+				9019F9233E2A8B04A82C1B8D0274F09F /* EXPMatchers+beSupersetOf.h in Headers */,
+				70545E4EA86C6E593A2A9F6731DA8F6D /* EXPMatchers+beTruthy.h in Headers */,
+				2945FAA75C956DD6A541EB51E42E6899 /* EXPMatchers+conformTo.h in Headers */,
+				02C7E3EC1E1DFDD7046BD26A67E92686 /* EXPMatchers+contain.h in Headers */,
+				76331E71086C8CD5118A69B046D8F0FB /* EXPMatchers+endWith.h in Headers */,
+				430CE433DB59FE090A8CC6AFCFA43337 /* EXPMatchers+equal.h in Headers */,
+				237FB063FB365119546C7B5006224F3B /* EXPMatchers+haveCountOf.h in Headers */,
+				C98F5401E5C1AB6512BE50C3B7CEA9BF /* EXPMatchers+match.h in Headers */,
+				339A0C1BFF72397A705959E03877DDDB /* EXPMatchers+postNotification.h in Headers */,
+				AAE75938ED3DD46BC00352B82D7CA890 /* EXPMatchers+raise.h in Headers */,
+				6EB2498C2AFB1DF8555CB7C1EF89CA5C /* EXPMatchers+raiseWithReason.h in Headers */,
+				E867CBF850D20C314BF4BD790432455D /* EXPMatchers+respondTo.h in Headers */,
+				6924E116731D7079958063A3EE0781ED /* EXPMatchers.h in Headers */,
+				4231743B6C143BDB4A5FBB032E6D3799 /* EXPUnsupportedObject.h in Headers */,
+				956FB3AB698AF3DA776A9F24AA79C229 /* NSObject+Expecta.h in Headers */,
+				60D3CCEB5B53542228790ABD8885AF42 /* NSValue+Expecta.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		37E21E3BEC55210F96E0E70DD1D5C67F /* ZettaKit-ZettaKit */ = {
+		2F501FE84845EAD97B9087DAFCBBEE0E /* Expecta */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 897D4DFC2660D5DE9C5C80054988C1DD /* Build configuration list for PBXNativeTarget "ZettaKit-ZettaKit" */;
+			buildConfigurationList = 57205495CF13B4EE93B13B7B0E3A1BD2 /* Build configuration list for PBXNativeTarget "Expecta" */;
 			buildPhases = (
-				E7AA3AA587AD9D9145D7629E423F79E3 /* Sources */,
-				0E532F182B9114AC5864CD2202E1E9DB /* Frameworks */,
-				8919C8C46410FFB4CC1B7E3FFD90A7B2 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ZettaKit-ZettaKit";
-			productName = "ZettaKit-ZettaKit";
-			productReference = 6F6B638A47FF34E7345CDC9C613B5BF5 /* ZettaKit.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
-		88184F740D065EA56B766F2AA3CB2C89 /* SocketRocket */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0A75FC6597F46D32F61F86B010D02A27 /* Build configuration list for PBXNativeTarget "SocketRocket" */;
-			buildPhases = (
-				8DC121BD1A36525B489610C4BAD570A6 /* Sources */,
-				FDF48C0355267306FF24C9CE20B786F2 /* Frameworks */,
-				1C40B99463DCE2A51192965EDC80AED3 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SocketRocket;
-			productName = SocketRocket;
-			productReference = 1B1AC55CD4A61F4881AAFEF03A88E0A8 /* libSocketRocket.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		92F54207AC5ED5FAB5B1B689810696A1 /* Pods-ZettaKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A9E1BFC8ACF1ED450E74A705819D3AF9 /* Build configuration list for PBXNativeTarget "Pods-ZettaKit" */;
-			buildPhases = (
-				FD0C7EE96871BBC4FB607FC5F44529C7 /* Sources */,
-				0D544177BFA6C087CB0CCA48DDE9F123 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				3E0781CC25F076742B2B271908EE9EA6 /* PBXTargetDependency */,
-				6DEF24F9675FA41EC8C41C2299ECEDA2 /* PBXTargetDependency */,
-				4915EEA61BDD6BF3155D1E6EDBCAF8CF /* PBXTargetDependency */,
-			);
-			name = "Pods-ZettaKit";
-			productName = "Pods-ZettaKit";
-			productReference = C5CE33960B44198C4DDC468605A3ADDC /* libPods-ZettaKit.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		AC28893AC336D2871E0F891E2F9BC36B /* Pods-Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 5DE37D97A94548C93B4798A701D6E6CE /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
-			buildPhases = (
-				20FC2AEB56BF07A1942116264703151B /* Sources */,
-				667C097AF62529A4EE39210679D0B102 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				9AFD0A94FC52C3B28FF457E81C12A89A /* PBXTargetDependency */,
-				D9338291CEA80BD13BB4370FF37DBA3F /* PBXTargetDependency */,
-				1C40712A43605DEE864503383CF916EE /* PBXTargetDependency */,
-				D5C04E8B886C831F3604E129E5D50136 /* PBXTargetDependency */,
-				F1226800D89C49313DFD91D34A7FB8F7 /* PBXTargetDependency */,
-			);
-			name = "Pods-Tests";
-			productName = "Pods-Tests";
-			productReference = 32093DC7D4B11A56582CC752D65A9B4E /* libPods-Tests.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		D3A64ECCCBFFF840589B13BDEC5658CA /* ReactiveCocoa */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B7916E61BC726ABF0726190528FC81F8 /* Build configuration list for PBXNativeTarget "ReactiveCocoa" */;
-			buildPhases = (
-				C28B0774EE43735AFC6403B93174058A /* Sources */,
-				46F5FA686EAAFFEC5C030B9245657E2B /* Frameworks */,
-				D1094359261984DF84AF9B72CCD084E4 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ReactiveCocoa;
-			productName = ReactiveCocoa;
-			productReference = 45018390477900ABFD4D22979EBCB816 /* libReactiveCocoa.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		D5822815B54870852F7739B671476F97 /* Expecta */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = FDBA6E19D31B9E8B9D71609F10454540 /* Build configuration list for PBXNativeTarget "Expecta" */;
-			buildPhases = (
-				3024B28429B19B3074F5DC5619BCA3D8 /* Sources */,
-				7D4AC4E217BE8C3D0DE429BB00CB87B2 /* Frameworks */,
-				EBBF84533DDBF3718D9D82A5D12029F9 /* Headers */,
+				143C0831AA95D723669324010D835391 /* Sources */,
+				199EF76AC47B3EE9FA80BE53835AB7B1 /* Frameworks */,
+				C6AD7852D34E8A80DFF3B8376BDE812F /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1808,36 +1718,110 @@
 			);
 			name = Expecta;
 			productName = Expecta;
-			productReference = 42511B8B3C1E29DB714664F1A8B2DC97 /* libExpecta.a */;
+			productReference = E05781440EB77042BAF5684942D1CC21 /* libExpecta.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		E3BBC7436BFB11CEA6FEA7154092CCE5 /* ZettaKit */ = {
+		3A1177A0BC321ECAB30C8B49CFFCBDFB /* SocketRocket */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = FB534589569CDA5BD50DAFFC869C3722 /* Build configuration list for PBXNativeTarget "ZettaKit" */;
+			buildConfigurationList = 592BAC1C465F11BCCE9A7A8934A2A2B7 /* Build configuration list for PBXNativeTarget "SocketRocket" */;
 			buildPhases = (
-				B87C812025AEB26231CE1BA0C2C8C96F /* Sources */,
-				BD5EB922B6B09583F86D2093E1ABD10A /* Frameworks */,
-				52D5529431ED321ACEB869604EFB5EC7 /* Headers */,
+				BEC35147C74F5ED71BDD0E08123AB15E /* Sources */,
+				5DB5F0F1F5EA0B8C3101B00DA5907C4C /* Frameworks */,
+				8C77439302755F490BE83B48ED105DDC /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				D0EB9CBBB67A682C9BF2E5169FE5BB3C /* PBXTargetDependency */,
-				3CF034F54E92982370AA57AC76795813 /* PBXTargetDependency */,
-				E2B005FAE403468C0695BF666248979C /* PBXTargetDependency */,
+			);
+			name = SocketRocket;
+			productName = SocketRocket;
+			productReference = DFBFD1EA2F0596148164F4C0A56247FB /* libSocketRocket.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		805C72C34E25E78947F6F6DAEE4C43CE /* ZettaKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 825DF432813611D8327F1D2ACDBB1482 /* Build configuration list for PBXNativeTarget "ZettaKit" */;
+			buildPhases = (
+				4323A50CC3115C92DEC4226C712DFE10 /* Sources */,
+				5B1E52E7EE4773E0C9FBE31F8647058F /* Frameworks */,
+				AC9CE58A03D683A84002DD9FE87D996B /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CF83A0B670988CE36B4C34976C1103AF /* PBXTargetDependency */,
+				CFD6BF580C6BFBDE03C9CEB514DDD0E4 /* PBXTargetDependency */,
+				BFB584ABE78AFA9932F71E341D318626 /* PBXTargetDependency */,
 			);
 			name = ZettaKit;
 			productName = ZettaKit;
-			productReference = 36A3CB14FC8276F4531C8118B497060B /* libZettaKit.a */;
+			productReference = 8D0862DFD1128B1E6C745191A5B7547F /* libZettaKit.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		E97A02DD69143CF53448FEACFEE09AEF /* Specta */ = {
+		ABBB78DB01D7200F26A57501800026B0 /* ZettaKit-ZettaKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5E726641067B8ACCD49E86227C2E5F41 /* Build configuration list for PBXNativeTarget "Specta" */;
+			buildConfigurationList = 771C434F1279152CF0D48396CB9066A0 /* Build configuration list for PBXNativeTarget "ZettaKit-ZettaKit" */;
 			buildPhases = (
-				12B00A252A2AD1A696B6702C99AE1990 /* Sources */,
-				42E77651B1258265D9FA78D4F4E152DC /* Frameworks */,
-				1DD715C561572FC13B66C4C40D077FDF /* Headers */,
+				8D86049CD7ACF64D5274904F2C05212C /* Sources */,
+				B262DFE933C2BC27DE0A53736F999E48 /* Frameworks */,
+				857D7B377DFCD70A973C5FDC87CD6BA0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ZettaKit-ZettaKit";
+			productName = "ZettaKit-ZettaKit";
+			productReference = B8EEF3578F570DFB16E2C0FD25D44FE5 /* ZettaKit.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		BA6580EAF3ADB684C45A447114CA3C75 /* Pods-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C4B199C0596B8AD888F87AC19CF7D9B2 /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
+			buildPhases = (
+				F2A0614F58F8E51119A9D85067533659 /* Sources */,
+				9E35AAAA17A9D5CD13555078071EE703 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				575688E5B062A82D6FA4C7C20B0287B4 /* PBXTargetDependency */,
+				473EFC66D314F2EFD5D6095B35AF9DF7 /* PBXTargetDependency */,
+				4E5B0B211EA61AEF2E80B1B2C6BE9FBE /* PBXTargetDependency */,
+				C8F104523B8165837572BECE15FCA0BC /* PBXTargetDependency */,
+				A2A18D43B5414F4716587F00AE3DA833 /* PBXTargetDependency */,
+			);
+			name = "Pods-Tests";
+			productName = "Pods-Tests";
+			productReference = FA4A7BB2D43ACEBC39C6CFFAD1E9763C /* libPods-Tests.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		C35C09903C1D1AAA23BA33603AF6378C /* Pods-ZettaKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3D0724F00C90AA674A07DF04E36684B2 /* Build configuration list for PBXNativeTarget "Pods-ZettaKit" */;
+			buildPhases = (
+				0277C2F92A1E7D53563A51299F71DAD7 /* Sources */,
+				C7EE037FE5E9D694C0445DD25F45E536 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DD8EA70F514F33583A609F3B2B7CD842 /* PBXTargetDependency */,
+				B3AE346EAD3FBAC9E895728092990D0B /* PBXTargetDependency */,
+				550881E247A6490F4BE30E629D3C799D /* PBXTargetDependency */,
+			);
+			name = "Pods-ZettaKit";
+			productName = "Pods-ZettaKit";
+			productReference = 710763F27A87396FAF50139B3A244876 /* libPods-ZettaKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		C656B1062EF5478BD86D177C779AD322 /* Specta */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A2F015C9A1FAC858E60CD24132B428F7 /* Build configuration list for PBXNativeTarget "Specta" */;
+			buildPhases = (
+				6F035C16F22F2AADE9347B2194B7A625 /* Sources */,
+				25B17FCFE08AD449B6273F0366106509 /* Frameworks */,
+				317A88106D142F3F1FB1D66BFF76E726 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1845,7 +1829,24 @@
 			);
 			name = Specta;
 			productName = Specta;
-			productReference = BC955D2828EDD99D6C7332F0E44CDE35 /* libSpecta.a */;
+			productReference = 32009289A420396C11D7461A264B8B09 /* libSpecta.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		EFBF56E35BBB16C86D5BE5D8756EFF7B /* ReactiveCocoa */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 48F150BE39F613AD1D658067A0762423 /* Build configuration list for PBXNativeTarget "ReactiveCocoa" */;
+			buildPhases = (
+				A34DC3172E30F0CEFD29B5143EA37FFF /* Sources */,
+				D879F4F5EA27F2035545E241CF58A40C /* Frameworks */,
+				B3D495894DF40839465A2B44655D6C1E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ReactiveCocoa;
+			productName = ReactiveCocoa;
+			productReference = 9E5D9AF4757F7C84882EBD74C7801A4D /* libReactiveCocoa.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -1865,24 +1866,24 @@
 				en,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = CCA510CFBEA2D207524CDA0D73C3B561 /* Products */;
+			productRefGroup = 6F58920903E0C65FA93344E0C2D7C8C1 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				D5822815B54870852F7739B671476F97 /* Expecta */,
-				AC28893AC336D2871E0F891E2F9BC36B /* Pods-Tests */,
-				92F54207AC5ED5FAB5B1B689810696A1 /* Pods-ZettaKit */,
-				D3A64ECCCBFFF840589B13BDEC5658CA /* ReactiveCocoa */,
-				88184F740D065EA56B766F2AA3CB2C89 /* SocketRocket */,
-				E97A02DD69143CF53448FEACFEE09AEF /* Specta */,
-				E3BBC7436BFB11CEA6FEA7154092CCE5 /* ZettaKit */,
-				37E21E3BEC55210F96E0E70DD1D5C67F /* ZettaKit-ZettaKit */,
+				2F501FE84845EAD97B9087DAFCBBEE0E /* Expecta */,
+				BA6580EAF3ADB684C45A447114CA3C75 /* Pods-Tests */,
+				C35C09903C1D1AAA23BA33603AF6378C /* Pods-ZettaKit */,
+				EFBF56E35BBB16C86D5BE5D8756EFF7B /* ReactiveCocoa */,
+				3A1177A0BC321ECAB30C8B49CFFCBDFB /* SocketRocket */,
+				C656B1062EF5478BD86D177C779AD322 /* Specta */,
+				805C72C34E25E78947F6F6DAEE4C43CE /* ZettaKit */,
+				ABBB78DB01D7200F26A57501800026B0 /* ZettaKit-ZettaKit */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		8919C8C46410FFB4CC1B7E3FFD90A7B2 /* Resources */ = {
+		857D7B377DFCD70A973C5FDC87CD6BA0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1892,300 +1893,318 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		12B00A252A2AD1A696B6702C99AE1990 /* Sources */ = {
+		0277C2F92A1E7D53563A51299F71DAD7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				08EA9841ABE58A0839BDDF539561B4CF /* SPTCallSite.m in Sources */,
-				2EC3163F84F7FA998CD2E4D976DA8F6D /* SPTCompiledExample.m in Sources */,
-				580EE17ADC44FCAB018F06C7C33368E5 /* SPTExample.m in Sources */,
-				7B624D69FD81E49B03BF95F0A49BD598 /* SPTExampleGroup.m in Sources */,
-				1BFD166355BEF23FA5997643114A199E /* SPTSharedExampleGroups.m in Sources */,
-				D8395F6D361B1793C5686AA6D99C1C52 /* SPTSpec.m in Sources */,
-				A6B903969894C2D9F884683ACC32F8EA /* SPTTestSuite.m in Sources */,
-				80F3ACAB998825EAE83E15190BC212A7 /* Specta-dummy.m in Sources */,
-				1DA72E09AECD333C4918E1EEE794F1A2 /* SpectaDSL.m in Sources */,
-				DF7520A01A56E51CAFE474C844C02412 /* SpectaUtility.m in Sources */,
-				BCA773A11AA4FCA536957D5BBB0CBCA6 /* XCTestCase+Specta.m in Sources */,
+				2A97822FA2775E9565567B8A71CBABFC /* Pods-ZettaKit-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		20FC2AEB56BF07A1942116264703151B /* Sources */ = {
+		143C0831AA95D723669324010D835391 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C54C1EDFADC8FBB1EA21B2FE359EBA44 /* Pods-Tests-dummy.m in Sources */,
+				CF95446EA555B49150EA7270096D78B2 /* EXPBlockDefinedMatcher.m in Sources */,
+				487899F028C39C1A518547A1AB2F625A /* EXPDoubleTuple.m in Sources */,
+				FDF72740DBC37AFACFED73ED42282383 /* Expecta-dummy.m in Sources */,
+				11CF0C44A36897A963C15B74C2AEC415 /* ExpectaObject.m in Sources */,
+				4383E0DB1B07B9EB3155EF5D5F27C7BA /* ExpectaSupport.m in Sources */,
+				104AFE24D01F1C4495926B40B53C5945 /* EXPExpect.m in Sources */,
+				779CFE8771E1EF63F1313ABEBCECAA4A /* EXPFloatTuple.m in Sources */,
+				49EFE75BAF060A33327F3CE8C18436F2 /* EXPMatcherHelpers.m in Sources */,
+				5F6D96E64F890BDC4A75B73C3D50A0DD /* EXPMatchers+beCloseTo.m in Sources */,
+				F1F4E65611F5567A86AF797EAC3E225B /* EXPMatchers+beFalsy.m in Sources */,
+				A7141BC83638F4B38D4D312BAE3BDAC4 /* EXPMatchers+beginWith.m in Sources */,
+				CB08C9C83ABDBE55762A423ED48491EF /* EXPMatchers+beGreaterThan.m in Sources */,
+				AD6791D14732A3C17164F61CC72FFB0D /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */,
+				A65C491577A425AF82C53F4A40A0A24B /* EXPMatchers+beIdenticalTo.m in Sources */,
+				2F9D3747596E4E074C3B776949091047 /* EXPMatchers+beInstanceOf.m in Sources */,
+				7436C602BB1CA7C91560C28DE749357B /* EXPMatchers+beInTheRangeOf.m in Sources */,
+				63D0CD4F0FB5A6103E1DDB46E876CBB6 /* EXPMatchers+beKindOf.m in Sources */,
+				C6671739E8C5904113586F8BEBBC9780 /* EXPMatchers+beLessThan.m in Sources */,
+				43A1104CA0C628C2F693902EADA32B8C /* EXPMatchers+beLessThanOrEqualTo.m in Sources */,
+				E06376455C1D5E45B97ACDC5438FC15B /* EXPMatchers+beNil.m in Sources */,
+				BD30B724A71CF5D6E93805B7615EC79C /* EXPMatchers+beSubclassOf.m in Sources */,
+				6D37BEAA1FC469C3582CACB4E9766502 /* EXPMatchers+beSupersetOf.m in Sources */,
+				5E8F33E777456DA63CA2D902508A9058 /* EXPMatchers+beTruthy.m in Sources */,
+				C2BFF99EB859FD7056CF72C4850693D1 /* EXPMatchers+conformTo.m in Sources */,
+				46F312CBB94BAE62B58D3D7AE28E8DBD /* EXPMatchers+contain.m in Sources */,
+				B33234F432A72D5E8B65694AE937B78F /* EXPMatchers+endWith.m in Sources */,
+				8059E5674B08670B0A002D564FFABF44 /* EXPMatchers+equal.m in Sources */,
+				562BE99A6F630E709218EB9B3CF36E90 /* EXPMatchers+haveCountOf.m in Sources */,
+				2239B5E63C5D2C1323D66F489F075C42 /* EXPMatchers+match.m in Sources */,
+				69EBB956302554EA37775F4D806BC4DD /* EXPMatchers+postNotification.m in Sources */,
+				7FEE0E8D094D7BCCAC7129473EE05ADC /* EXPMatchers+raise.m in Sources */,
+				A26F992E8831118311F3DB7CB830595A /* EXPMatchers+raiseWithReason.m in Sources */,
+				E2EBD18BA89D3FF648947DF31FA12D44 /* EXPMatchers+respondTo.m in Sources */,
+				40F505E69B8595361C2A7528DDA222B6 /* EXPUnsupportedObject.m in Sources */,
+				872948DAF79618AD725E0BF364E5DDD4 /* NSValue+Expecta.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3024B28429B19B3074F5DC5619BCA3D8 /* Sources */ = {
+		4323A50CC3115C92DEC4226C712DFE10 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC3687F00A97092E75F467D710E21C22 /* EXPBlockDefinedMatcher.m in Sources */,
-				190EBCD9EFD51C60314B23A4BDBF5ACF /* EXPDoubleTuple.m in Sources */,
-				F15D815BB87C87A49617C6D0FE854075 /* EXPExpect.m in Sources */,
-				E0614C42D918326AC30FA92A4361AAA7 /* EXPFloatTuple.m in Sources */,
-				99322F6F076ED2C4E79A56C347C1E51C /* EXPMatcherHelpers.m in Sources */,
-				C405F06E7766EAA8C4B3BE163EF0F2EC /* EXPMatchers+beCloseTo.m in Sources */,
-				80AC87407A3E1FBE91CC221DCA9D8333 /* EXPMatchers+beFalsy.m in Sources */,
-				0786AED0EF59E2200B76F30C1ECCDE44 /* EXPMatchers+beGreaterThan.m in Sources */,
-				1643F20F3E78395541907BA3E30A6177 /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */,
-				B45FFA09D7FDDEDF72F6BA657F27FCB7 /* EXPMatchers+beIdenticalTo.m in Sources */,
-				251E41D55DB8988FE2497F2CDB70910C /* EXPMatchers+beInTheRangeOf.m in Sources */,
-				374D52A5032D68A37D316940BAB3C656 /* EXPMatchers+beInstanceOf.m in Sources */,
-				15A4432094FEF202DB5614B53544D617 /* EXPMatchers+beKindOf.m in Sources */,
-				4FD8A55CC93C7D950B444CC55D764781 /* EXPMatchers+beLessThan.m in Sources */,
-				9A9E34137CF5EE0F4AD2E333CC2302A2 /* EXPMatchers+beLessThanOrEqualTo.m in Sources */,
-				75E013B9C4722F9094A22932A38A6D47 /* EXPMatchers+beNil.m in Sources */,
-				202A870C640180ED0EF2959EC11BF11E /* EXPMatchers+beSubclassOf.m in Sources */,
-				2C23DC1AEE0D3E5D30BFB8712DF33E8E /* EXPMatchers+beSupersetOf.m in Sources */,
-				12FE84EABD1399FBD048EE5364AE414B /* EXPMatchers+beTruthy.m in Sources */,
-				879DDE3C5F6939680AEF9132529637EF /* EXPMatchers+beginWith.m in Sources */,
-				C14ED0320B0C3A1722B881C111491843 /* EXPMatchers+conformTo.m in Sources */,
-				E2716F65324D3881D61001DBCEA25C21 /* EXPMatchers+contain.m in Sources */,
-				95BD576E322CC3450069B6445241B44A /* EXPMatchers+endWith.m in Sources */,
-				4991020C842F25B083DF0EF25CB8A544 /* EXPMatchers+equal.m in Sources */,
-				4A9BB5B827C74024A8B0F0D7D4E62A84 /* EXPMatchers+haveCountOf.m in Sources */,
-				130FFE26762F54717B4E4DBEA29F5A08 /* EXPMatchers+match.m in Sources */,
-				58B62688542864D65412AE327DD6E579 /* EXPMatchers+postNotification.m in Sources */,
-				38BEF6B499CFA1DAC9FB9219AD12BD50 /* EXPMatchers+raise.m in Sources */,
-				8AE736B3465BDE90D4FA6424FBCDFF50 /* EXPMatchers+raiseWithReason.m in Sources */,
-				DDD8EF2F315AC545AD97B523C7D35878 /* EXPMatchers+respondTo.m in Sources */,
-				5E3A4C667A3AF193116CE223BE992AA7 /* EXPUnsupportedObject.m in Sources */,
-				2745F2B9E4AE8FD2D173177BF10C8C32 /* Expecta-dummy.m in Sources */,
-				554B6C009BE299FD6D2328C4C64E7DE4 /* ExpectaObject.m in Sources */,
-				FE031FEDB0693699EEAED4ACA0CF39E2 /* ExpectaSupport.m in Sources */,
-				5FE1CB196B26EAE44C569759C6CD1E2C /* NSValue+Expecta.m in Sources */,
+				6A5B04301BA04CABCAB2FFF304BA41C1 /* compressor.m in Sources */,
+				56BA73545D71469B1351E8E5E52666F1 /* framer.m in Sources */,
+				48F35EE31CCDEE774A40DC49DD9C90E1 /* ispdy.m in Sources */,
+				8F1FC7AA6320D68EBA83859A4341B43F /* LICENSE in Sources */,
+				C68CEA077E3E8B3020BED7465AB511E8 /* loop.m in Sources */,
+				DF3621D5D7AD0092747EC1FD11E860EB /* parser.m in Sources */,
+				9AB6C7A774669A1D6765FF1632FA9EC3 /* README.md in Sources */,
+				7BB41D063245E855EB861C7B4487665A /* request.m in Sources */,
+				7A64247782D5E9CA0C734509DCEDF5E7 /* scheduler.m in Sources */,
+				4ADD3AEC4E63944EF2333DB051403C36 /* ZettaKit-dummy.m in Sources */,
+				B00AF4BC0674F7DBAE76380325AE95CA /* ZIKDevice.m in Sources */,
+				A7FBE4574FA8053666E20CF5BBF86DEA /* ZIKLink.m in Sources */,
+				22246F6F68C31EC00EF9E1EE812DC054 /* ZIKLogStreamEntry.m in Sources */,
+				179F6EC775DF653A5F49456C914A32A9 /* ZIKMultiplexStreamEntry.m in Sources */,
+				C6C1D3F9E43C370FF403584064C22EDA /* ZIKPubSubBroker.m in Sources */,
+				9A81AC7F2D86E9A58B30494D3B7016DD /* ZIKQuery.m in Sources */,
+				DE4648DA426DFFE4B911BFDE866E0661 /* ZIKQueryResponse.m in Sources */,
+				FF1C2A1C7239535E512486CDEE6AB71C /* ZIKRoot.m in Sources */,
+				601C0C80E23E97A184E782E2A67B6B2E /* ZIKServer.m in Sources */,
+				6229FFA2E624EE44EC0FEA533C7E717E /* ZIKSession.m in Sources */,
+				259D7E10827968575982A3C448CB270B /* ZIKSpdyDelegate.m in Sources */,
+				0C41A5A97273F0C8C3F4BA7A06A561CD /* ZIKStream.m in Sources */,
+				ED9667511E18D13D2D045BFC84692563 /* ZIKStreamEntry.m in Sources */,
+				CD8B5A6C1258DB377F7CC85F6D8929FD /* ZIKTransition.m in Sources */,
+				CAA8C4EA98297C539FAB169DC8162A81 /* ZIKUtil.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8DC121BD1A36525B489610C4BAD570A6 /* Sources */ = {
+		6F035C16F22F2AADE9347B2194B7A625 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2BCEB05D07155176A17AD8F51136F674 /* SRWebSocket.m in Sources */,
-				3DEF75FBE8A8A90D8862CB967CB8EB27 /* SocketRocket-dummy.m in Sources */,
+				123536D730F16EC7409B2813BD5741B9 /* Specta-dummy.m in Sources */,
+				3212A950FA4CFC89CB17C4060980AD85 /* SpectaDSL.m in Sources */,
+				287416B2D7A394C1863261873DBD2A41 /* SpectaUtility.m in Sources */,
+				712B8540947B6861B2B794A840329FCA /* SPTCallSite.m in Sources */,
+				2CBBDB7D13C945F3F738F94BD0FA676A /* SPTCompiledExample.m in Sources */,
+				B329F06806AD33648410CB4A60D6181B /* SPTExample.m in Sources */,
+				A2E7A454C48BEBC5AD3D190319F5F97E /* SPTExampleGroup.m in Sources */,
+				45636CD2498FE75E3AEAF01E6DA06800 /* SPTSharedExampleGroups.m in Sources */,
+				A0B247D8D1BC3D5647750CDEA5FE4DDD /* SPTSpec.m in Sources */,
+				442A2D72D984E809910A5C7261488849 /* SPTTestSuite.m in Sources */,
+				FD64BCBD66378EF10897C480FE7143E3 /* XCTestCase+Specta.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B87C812025AEB26231CE1BA0C2C8C96F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				82AA8237410AA975A398827ACAFEA6E0 /* LICENSE in Sources */,
-				996AB105A2F5A9D339F67BF98089C63C /* README.md in Sources */,
-				198D1819D0DE25B0CE556A683FDBB5D3 /* ZIKDevice.m in Sources */,
-				B50322B046EBAB1F11A0D44781D8493D /* ZIKLink.m in Sources */,
-				E3E26575D2A8E16AD052D57E0B08BC80 /* ZIKLogStreamEntry.m in Sources */,
-				95D0DC080D24C070CE6512B2BC51A00E /* ZIKMultiplexStreamEntry.m in Sources */,
-				3FE59D8FC674BA696E01DA072748271B /* ZIKPubSubBroker.m in Sources */,
-				3EC753ED3A1B5343405344B5D5828EC8 /* ZIKQuery.m in Sources */,
-				038F5CFD3248085D90656C31ACB6E71F /* ZIKRoot.m in Sources */,
-				E89C8D40E19EDB82D9F46BD45ABA2BE9 /* ZIKServer.m in Sources */,
-				977F5E4E2DB98B7CA2CF08B882048430 /* ZIKSession.m in Sources */,
-				5156708912B3AC0EFA2469BE5298BC68 /* ZIKSpdyDelegate.m in Sources */,
-				D5AC23B010FC6F0BF9782B7BC26DCE0F /* ZIKStream.m in Sources */,
-				0C495ED185087DE7F3FE71E3A382A72C /* ZIKStreamEntry.m in Sources */,
-				F37FE3DEAC2F1973CA69A76712FE1A0D /* ZIKTransition.m in Sources */,
-				3D64EEB7E6A1C368E9261F22138C244F /* ZIKUtil.m in Sources */,
-				9358AD65D0CD80ADAC6A37B8B7A3EEC4 /* ZettaKit-dummy.m in Sources */,
-				8341D6CAD7AE2B33590C8147513A6DE9 /* compressor.m in Sources */,
-				79DC28F597FA0AF120A8B9D2634E84C8 /* framer.m in Sources */,
-				0D38231F8B9AAE9ADC6DA680FDA4F6DD /* ispdy.m in Sources */,
-				FA9E642CF9C0951F281830BBB9EB9B78 /* loop.m in Sources */,
-				CE4191522CD109C5EF82F321FAC498E4 /* parser.m in Sources */,
-				6C334EF65FA5C48AA3A5306A2497FC42 /* request.m in Sources */,
-				98D16CC61273DF365D7D1FDC220A61CF /* scheduler.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		C28B0774EE43735AFC6403B93174058A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				311CAC13FF8F181149C1187ED16D316F /* NSArray+RACSequenceAdditions.m in Sources */,
-				9B9FF575A57BC5A326E01324BC430308 /* NSData+RACSupport.m in Sources */,
-				13582AC0E07964AF58B2B147568DE2A5 /* NSDictionary+RACSequenceAdditions.m in Sources */,
-				CCC0870C6FDB9DBF069DEAAD62A17100 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
-				3DE1BF7BF8CBFC343C1B231EB589CEEC /* NSFileHandle+RACSupport.m in Sources */,
-				40746E34173E60376213988F8146550A /* NSIndexSet+RACSequenceAdditions.m in Sources */,
-				03FB8E16A98E72F50C904908CA4E06BC /* NSInvocation+RACTypeParsing.m in Sources */,
-				F72012F176EBDC3A43084821568201BE /* NSNotificationCenter+RACSupport.m in Sources */,
-				798C6CEDF3BE134A2198A9874D1810E6 /* NSObject+RACDeallocating.m in Sources */,
-				CA8B711843F3D0DE16A764C26FF87AD6 /* NSObject+RACDescription.m in Sources */,
-				92016529A9885C6BF3724468319F058E /* NSObject+RACKVOWrapper.m in Sources */,
-				6FAE46DD86F070280779C9A69510D53F /* NSObject+RACLifting.m in Sources */,
-				2A1483DE10527284B98CC5BF4ED1E73C /* NSObject+RACPropertySubscribing.m in Sources */,
-				B8B54EA62B1D90C028FE2B431844098E /* NSObject+RACSelectorSignal.m in Sources */,
-				2C9D47DF0AF13A3010462D40D3F989D7 /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
-				5B589842C88FB2F0FEA5E2E0415B9272 /* NSSet+RACSequenceAdditions.m in Sources */,
-				F9A605F05BE214E07E34F181A5127A38 /* NSString+RACKeyPathUtilities.m in Sources */,
-				5DAF61ACA0EF311EF313139EA8172995 /* NSString+RACSequenceAdditions.m in Sources */,
-				582CC301637EA96772EC7E3569D11A57 /* NSString+RACSupport.m in Sources */,
-				62ECCDB84FBC178EC784C6A0C8D25A40 /* NSURLConnection+RACSupport.m in Sources */,
-				4D3DE0D21602EBC029BA1848F0C90848 /* NSUserDefaults+RACSupport.m in Sources */,
-				BE00E57A48DA27A2D02009D1582CD9C2 /* RACArraySequence.m in Sources */,
-				BAA6443ECC3509B5681215B29ABF4C7B /* RACBacktrace.m in Sources */,
-				9AB4BE742E7937452B88BA5BBF914007 /* RACBehaviorSubject.m in Sources */,
-				33A7BA0595B98BAA6DFA9DDC8433935B /* RACBlockTrampoline.m in Sources */,
-				8477700FA844329D5CB2EAFD186A9B36 /* RACChannel.m in Sources */,
-				5E90854F0265DFC2A143615E0E1DE173 /* RACCommand.m in Sources */,
-				14D59D21E9F244CCAEE1CDA608281768 /* RACCompoundDisposable.m in Sources */,
-				386F8A3BCB064371F0BF2C343FD50C5C /* RACCompoundDisposableProvider.d in Sources */,
-				C515672C64B8CFDD8DA630E3B8236493 /* RACDelegateProxy.m in Sources */,
-				1BC608155C585E35636A79EA51D1A44F /* RACDisposable.m in Sources */,
-				FC7E5B8419BF03F985456C9B9DC7125E /* RACDynamicSequence.m in Sources */,
-				8BB6AD6178E6CCBA6DED3C434F7828AF /* RACDynamicSignal.m in Sources */,
-				8D7305C6505DF1A47CF4AC9636C9292F /* RACEXTRuntimeExtensions.m in Sources */,
-				00728FA3CB18FD025773A2F91D100E49 /* RACEagerSequence.m in Sources */,
-				6DE9508844E5026B224F0749878FCE47 /* RACEmptySequence.m in Sources */,
-				D6512D8345593243DE6E96B75EB00991 /* RACEmptySignal.m in Sources */,
-				D92C639CB9FA54D23CE6530221C33E4B /* RACErrorSignal.m in Sources */,
-				A9BFD880013117F7CF66D6F32DC2CAD0 /* RACEvent.m in Sources */,
-				12F70B413837D7E921278295813D5200 /* RACGroupedSignal.m in Sources */,
-				73542480627EFC2762EC1D3042335BFF /* RACImmediateScheduler.m in Sources */,
-				FD1C3C709DB8A0CEA5471CABCA2FD6CB /* RACIndexSetSequence.m in Sources */,
-				4B3175700FE9F2B219A822B7EDECA0B7 /* RACKVOChannel.m in Sources */,
-				C74CC5619A1ED5E8A3553D43B5C97028 /* RACKVOProxy.m in Sources */,
-				6274FD73F09EC2CF121F802F70140DFE /* RACKVOTrampoline.m in Sources */,
-				AB0BC7F16D3C5455CE5F431543F0FD84 /* RACMulticastConnection.m in Sources */,
-				1A4A3D486667809C0DC731EBBE2D4A59 /* RACObjCRuntime.m in Sources */,
-				2D5E57A0D2EC1BCF9A82ECBCA0713C3D /* RACPassthroughSubscriber.m in Sources */,
-				BFCE6C8A7FF824E243415A76EE5687BF /* RACQueueScheduler.m in Sources */,
-				071F0030E3FCAD7E914954879A1816AE /* RACReplaySubject.m in Sources */,
-				1B479B34C278460848338A2456BD2D59 /* RACReturnSignal.m in Sources */,
-				A5D7747C1CC85D8D024FCCDD8B3098DC /* RACScheduler.m in Sources */,
-				8DF78B4AFAB3C125B26FDBCAE519B856 /* RACScopedDisposable.m in Sources */,
-				4C6E8246699E4D745ABAA0DA9133AFB2 /* RACSequence.m in Sources */,
-				E23945891D00F2393BCB85879FA51ACE /* RACSerialDisposable.m in Sources */,
-				0965013CD5E3AAC8B17A54B5C680C75F /* RACSignal+Operations.m in Sources */,
-				55A1F246C81D4AF8DB47ECC98A20DA00 /* RACSignal.m in Sources */,
-				FC44FE9CED2B9AAF81C88E8ADBED0B4D /* RACSignalProvider.d in Sources */,
-				CA3D140B1572DA580B270999D5B85007 /* RACSignalSequence.m in Sources */,
-				7E9CED19AB172CCEA0E3CD7B909C62B5 /* RACStream.m in Sources */,
-				C4DAE253D99AB1CE0CA14740EE484164 /* RACStringSequence.m in Sources */,
-				FE686BD9EECF15BCF71F193E248BE6AF /* RACSubject.m in Sources */,
-				956F617F4A4989F53049F8BD309BFF90 /* RACSubscriber.m in Sources */,
-				ECDFF296E45100EC4849A663DD258817 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
-				0CFC315F73A199C37C77E906953A7A45 /* RACSubscriptionScheduler.m in Sources */,
-				8777929E50F4214719FA63A12188D8A0 /* RACTargetQueueScheduler.m in Sources */,
-				05AA13D8A34BDB9F6C0D24054A135AE4 /* RACTestScheduler.m in Sources */,
-				F878A4D111142DECB86F46B195CAA639 /* RACTuple.m in Sources */,
-				EDF5DE2AD5CC3313AE8CFDDF7569B2C6 /* RACTupleSequence.m in Sources */,
-				8884ABF795D44AD705FD883B37F92D62 /* RACUnarySequence.m in Sources */,
-				3EC719AACA92815955366285ECF9F25B /* RACUnit.m in Sources */,
-				FAD0F48713D0CAC1585E03ABD5E2A396 /* RACValueTransformer.m in Sources */,
-				C8D7A9D4DA4214C519D7D35DEA516D01 /* ReactiveCocoa-dummy.m in Sources */,
-				51F5F030F97412AB1EF8CBCBD356F4DE /* UIActionSheet+RACSignalSupport.m in Sources */,
-				BBFC3693A83D237CB589026016521EF6 /* UIAlertView+RACSignalSupport.m in Sources */,
-				9CF364D8054F811CC83935BFE31587C7 /* UIBarButtonItem+RACCommandSupport.m in Sources */,
-				8194F33B1F05DCF6FE35282BB5FDDF85 /* UIButton+RACCommandSupport.m in Sources */,
-				64E1D95C99BCFBC20551C5D703EB2B8D /* UICollectionReusableView+RACSignalSupport.m in Sources */,
-				B8B20783EF02164BE8C059FB21919DF6 /* UIControl+RACSignalSupport.m in Sources */,
-				8EA940BC2B89B4214909C237323748F8 /* UIControl+RACSignalSupportPrivate.m in Sources */,
-				079157EB995CC3507A04AD8D4D154F6E /* UIDatePicker+RACSignalSupport.m in Sources */,
-				C61ADEC820AE7DA9AC3E859292B4FC0C /* UIGestureRecognizer+RACSignalSupport.m in Sources */,
-				87407A7D9DFF81394E6003FC95FCDD0B /* UIImagePickerController+RACSignalSupport.m in Sources */,
-				94778C82680B97105B2D931FBF7E59F4 /* UIRefreshControl+RACCommandSupport.m in Sources */,
-				CF27535860BB51E65495A9F9831B1D12 /* UISegmentedControl+RACSignalSupport.m in Sources */,
-				3444E14B60E5CBA10BF566B28124E4C1 /* UISlider+RACSignalSupport.m in Sources */,
-				38CC62C595A2CE45AF600044F597C8EF /* UIStepper+RACSignalSupport.m in Sources */,
-				F41D0F5E256478980067E7AC7890D9F2 /* UISwitch+RACSignalSupport.m in Sources */,
-				E0FF4EC4EAB8ABD02E7568A9C4188DE8 /* UITableViewCell+RACSignalSupport.m in Sources */,
-				5C82ED4E0681E74CE3BBE639EA823A8B /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */,
-				90EF778245546FE3E72C92591ADE6275 /* UITextField+RACSignalSupport.m in Sources */,
-				312564372D2BA844E4A8C73B467888BF /* UITextView+RACSignalSupport.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E7AA3AA587AD9D9145D7629E423F79E3 /* Sources */ = {
+		8D86049CD7ACF64D5274904F2C05212C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FD0C7EE96871BBC4FB607FC5F44529C7 /* Sources */ = {
+		A34DC3172E30F0CEFD29B5143EA37FFF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4CFB0DC81F9E4C7172DADAFF1AD02D09 /* Pods-ZettaKit-dummy.m in Sources */,
+				3A1133F091D300CC917CF48F40CE4FA2 /* NSArray+RACSequenceAdditions.m in Sources */,
+				12186DCF83338B6C8BFA9B682D6D24B5 /* NSData+RACSupport.m in Sources */,
+				15ACE639ECD54D13B0B7F6E5FC929117 /* NSDictionary+RACSequenceAdditions.m in Sources */,
+				EBAD7BC6E37C0B4B04CE1D05A6D60B16 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
+				7D848B8E3211F93AA74FF1CF285E356F /* NSFileHandle+RACSupport.m in Sources */,
+				7A0E82DE694B41C32A134705DCF9CB82 /* NSIndexSet+RACSequenceAdditions.m in Sources */,
+				914D7E610C60E9313CD071F09B4E230A /* NSInvocation+RACTypeParsing.m in Sources */,
+				B5C1AC7DAD518D7C9352974466822878 /* NSNotificationCenter+RACSupport.m in Sources */,
+				86B8749C1E25DE121BAFC8887FEF7B1A /* NSObject+RACDeallocating.m in Sources */,
+				DD33E05235E9B5875250B93D0E7F56B0 /* NSObject+RACDescription.m in Sources */,
+				7310778D17E2311C22F202B7352A2849 /* NSObject+RACKVOWrapper.m in Sources */,
+				BED8C899A74A1448722C8F3C91136835 /* NSObject+RACLifting.m in Sources */,
+				2EA4085745BF7F724A725AF1D6A8E035 /* NSObject+RACPropertySubscribing.m in Sources */,
+				4A145A5D08363FC3A99FB837E8D4595A /* NSObject+RACSelectorSignal.m in Sources */,
+				4E4A734703008A37387722653CFDE43C /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
+				A5CBB8F1FF36B9AAAE338F47FA0C6407 /* NSSet+RACSequenceAdditions.m in Sources */,
+				18B62BC494CBD23821B92B7FCE62C6A1 /* NSString+RACKeyPathUtilities.m in Sources */,
+				B3FC415CBDF5FB64EF7776A46C13FBCB /* NSString+RACSequenceAdditions.m in Sources */,
+				DF4C193E624B6C52915C387A78844678 /* NSString+RACSupport.m in Sources */,
+				12EF88FF8FDBF1E87878F36C5F18FFD9 /* NSURLConnection+RACSupport.m in Sources */,
+				6303225F7695C870841D204AD525DFBB /* NSUserDefaults+RACSupport.m in Sources */,
+				F03EB9DB61DC356DBCFB7A1A57E2BE68 /* RACArraySequence.m in Sources */,
+				3D730E07BA970AE078A267A1E4DB558F /* RACBacktrace.m in Sources */,
+				0D4E4F1D7D7AF31597B60B548BFEEC26 /* RACBehaviorSubject.m in Sources */,
+				EF3359AAB00AAD69C136919523F141E6 /* RACBlockTrampoline.m in Sources */,
+				EA5D9D810ECB1BA7D45DA5C027B32904 /* RACChannel.m in Sources */,
+				E320C67F4E9AE79753C9386EC8D788B3 /* RACCommand.m in Sources */,
+				7BDB187E770B1DDBE63EFB16291A3A1F /* RACCompoundDisposable.m in Sources */,
+				E1B3EAD1F5549963CC9C5758A0D4C371 /* RACCompoundDisposableProvider.d in Sources */,
+				AA548C9C8DEA653FD75BAFB139C0AB64 /* RACDelegateProxy.m in Sources */,
+				4F64ADFA8D627F23453CB0DFF464B947 /* RACDisposable.m in Sources */,
+				5779A991DA5DC2F95EC3A27E38846DAF /* RACDynamicSequence.m in Sources */,
+				78DE5C99258885DF3CEF9AD84AEA5AC9 /* RACDynamicSignal.m in Sources */,
+				AB757776E1CC6453D71DCB93D77AE0F8 /* RACEagerSequence.m in Sources */,
+				744266F2FAF0D16A23F6124D28347572 /* RACEmptySequence.m in Sources */,
+				4D04E30E11B6CCC821CD59161A4BA11C /* RACEmptySignal.m in Sources */,
+				60C1ED751BB20883F9A265CD00AE555B /* RACErrorSignal.m in Sources */,
+				B0F05879F1187D4BD4E72BA3B1F358EF /* RACEvent.m in Sources */,
+				198892558E3058F7CE0AD3E922FD558C /* RACEXTRuntimeExtensions.m in Sources */,
+				515363DB53423930798EFC7ACD9A0F5B /* RACGroupedSignal.m in Sources */,
+				7F626CA39387F4C5EDC10B7EB3E86912 /* RACImmediateScheduler.m in Sources */,
+				6F4113A837A4F458D1FB1C1174635C5C /* RACIndexSetSequence.m in Sources */,
+				8DDC1E0DA0EB3A1A891D8E01240490C4 /* RACKVOChannel.m in Sources */,
+				B1B1C39CD03A2D0856BCD68A6D935074 /* RACKVOProxy.m in Sources */,
+				020E0B2DFBBEC0BCF021B5E3584F0341 /* RACKVOTrampoline.m in Sources */,
+				AF28821E25C5DFDE9BB6D24F0DC1CC6A /* RACMulticastConnection.m in Sources */,
+				2E4B94864F1FCE3A6BCC5D72A1E90D37 /* RACObjCRuntime.m in Sources */,
+				A8A1AA0CF6E18820F61EAFFF5DA5DECC /* RACPassthroughSubscriber.m in Sources */,
+				85AE749E567451A1133BFD294FBAC7F7 /* RACQueueScheduler.m in Sources */,
+				FF6627DB2E5BD34FD3473AB4E217A7A8 /* RACReplaySubject.m in Sources */,
+				A456129FCCD2D28C4818F1A3D77D82BA /* RACReturnSignal.m in Sources */,
+				4544E360AC49B1E575F1CDD0A4EBCA68 /* RACScheduler.m in Sources */,
+				52A757E5F1E1C205F05B0C903B26B8CE /* RACScopedDisposable.m in Sources */,
+				FB858FB338BE34B7D8B9B30DAEF749D3 /* RACSequence.m in Sources */,
+				C3D134C629E261CCA089C0DC4AEBC007 /* RACSerialDisposable.m in Sources */,
+				225A69DEBB0E464C39A7C2DFE63C3622 /* RACSignal+Operations.m in Sources */,
+				7661E0854F2F6695C39FE1D06084139E /* RACSignal.m in Sources */,
+				4C2666EDEC551C904FCDA9CB8490F454 /* RACSignalProvider.d in Sources */,
+				2E61C4EA8BD51397155A072BFE65CAE9 /* RACSignalSequence.m in Sources */,
+				4E05B5F0DA3C33A8A78D1FDDF940ACDB /* RACStream.m in Sources */,
+				79E8D9A2AE13C401A691A0F5F5193AB8 /* RACStringSequence.m in Sources */,
+				A7157C2DBB63FA5B066F044D183C51F5 /* RACSubject.m in Sources */,
+				A448B6601A17181B02F2EB745CDFCB0E /* RACSubscriber.m in Sources */,
+				4FB93B5770B13BBEF4F6577EC27587E9 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
+				4205D5CE9C3EF7BECB20B1D2367571CD /* RACSubscriptionScheduler.m in Sources */,
+				B9BEEBCA5B83DACDADF5BBA51B8F5D27 /* RACTargetQueueScheduler.m in Sources */,
+				8B31BEACA5CB98AAF5CA41765D52D325 /* RACTestScheduler.m in Sources */,
+				753A3A0F59A082DDB1DBB70315BCBC01 /* RACTuple.m in Sources */,
+				61856AF4DF00DE7BA14D9AF984B3AF0A /* RACTupleSequence.m in Sources */,
+				FC64CB0A024BDD72D8BCC9EE1D7A7633 /* RACUnarySequence.m in Sources */,
+				DA90D31E66525C183D17099299D1B69F /* RACUnit.m in Sources */,
+				C2DFFE2BB693FEFEF97FDE6516273C42 /* RACValueTransformer.m in Sources */,
+				BBC9823C155128D9175686AC6356B0EB /* ReactiveCocoa-dummy.m in Sources */,
+				63CE42D592F8CC7F5FDAC6467DA97700 /* UIActionSheet+RACSignalSupport.m in Sources */,
+				C20A1001DEA50D29452E4D48E37956A9 /* UIAlertView+RACSignalSupport.m in Sources */,
+				317E5DAF107C40137DB1229BA1931AE0 /* UIBarButtonItem+RACCommandSupport.m in Sources */,
+				1B1A93E0402B44A7371C43CB744222E8 /* UIButton+RACCommandSupport.m in Sources */,
+				EB779FA52BDF5199781320DA70D4C46B /* UICollectionReusableView+RACSignalSupport.m in Sources */,
+				87F267559642F8B0732681A85017A3C4 /* UIControl+RACSignalSupport.m in Sources */,
+				88D782327ADBCE0A7C3FC4AB67C22A96 /* UIControl+RACSignalSupportPrivate.m in Sources */,
+				EB7CADC7426A507E1DC4495D7B5C4033 /* UIDatePicker+RACSignalSupport.m in Sources */,
+				A7FBCAEE72BA12BDF7CECCC1442C060A /* UIGestureRecognizer+RACSignalSupport.m in Sources */,
+				9B88BAAAE17DEDD02052E5D81C22D13C /* UIImagePickerController+RACSignalSupport.m in Sources */,
+				309EF4B10150536624C7B2263D346BD3 /* UIRefreshControl+RACCommandSupport.m in Sources */,
+				00E9D36D6B005B45689F434FF9D3FD88 /* UISegmentedControl+RACSignalSupport.m in Sources */,
+				BC8F67A730644617AC7638EA55BBD17E /* UISlider+RACSignalSupport.m in Sources */,
+				6E426A235DED5D5EE942B3FA58A140B6 /* UIStepper+RACSignalSupport.m in Sources */,
+				8EFC503E3E3152C8319F86FFF255B4E3 /* UISwitch+RACSignalSupport.m in Sources */,
+				FA8F32D61A7CDD423DC31038E0945D7C /* UITableViewCell+RACSignalSupport.m in Sources */,
+				A44CCD9D1048F5997DAFF1F76F690428 /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */,
+				CCB7B7C373368E7335588FF9E1BB1B9C /* UITextField+RACSignalSupport.m in Sources */,
+				F7BE82F1A42B7BB6E76BF131C5945744 /* UITextView+RACSignalSupport.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BEC35147C74F5ED71BDD0E08123AB15E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB57793A8FF6E82F06F1F65ED0065D44 /* SocketRocket-dummy.m in Sources */,
+				423A2372975055CBCA1BE8E83E6CB282 /* SRWebSocket.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F2A0614F58F8E51119A9D85067533659 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C2398ABE94065D7EFA1D806E6EE6591B /* Pods-Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1C40712A43605DEE864503383CF916EE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SocketRocket;
-			target = 88184F740D065EA56B766F2AA3CB2C89 /* SocketRocket */;
-			targetProxy = 5F7E852D1153D68AAE7F50B47D173CA6 /* PBXContainerItemProxy */;
-		};
-		3CF034F54E92982370AA57AC76795813 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SocketRocket;
-			target = 88184F740D065EA56B766F2AA3CB2C89 /* SocketRocket */;
-			targetProxy = A9CAA3C37F35BF99A43A339ABC3F8E4B /* PBXContainerItemProxy */;
-		};
-		3E0781CC25F076742B2B271908EE9EA6 /* PBXTargetDependency */ = {
+		473EFC66D314F2EFD5D6095B35AF9DF7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ReactiveCocoa;
-			target = D3A64ECCCBFFF840589B13BDEC5658CA /* ReactiveCocoa */;
-			targetProxy = 4EFB56BC0035EAEA5E4ADB8FB30EB9D4 /* PBXContainerItemProxy */;
+			target = EFBF56E35BBB16C86D5BE5D8756EFF7B /* ReactiveCocoa */;
+			targetProxy = 627C7FF33AA7A9FF6CCDFD5715C87177 /* PBXContainerItemProxy */;
 		};
-		4915EEA61BDD6BF3155D1E6EDBCAF8CF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ZettaKit;
-			target = E3BBC7436BFB11CEA6FEA7154092CCE5 /* ZettaKit */;
-			targetProxy = ADEBA8B8691F42EAD97CC6FBA908D599 /* PBXContainerItemProxy */;
-		};
-		6DEF24F9675FA41EC8C41C2299ECEDA2 /* PBXTargetDependency */ = {
+		4E5B0B211EA61AEF2E80B1B2C6BE9FBE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SocketRocket;
-			target = 88184F740D065EA56B766F2AA3CB2C89 /* SocketRocket */;
-			targetProxy = 25F35F0CF5FC2C66A0B5EB5DCF6D6615 /* PBXContainerItemProxy */;
+			target = 3A1177A0BC321ECAB30C8B49CFFCBDFB /* SocketRocket */;
+			targetProxy = D2E4037AAF8057EBD292BE499818A99F /* PBXContainerItemProxy */;
 		};
-		9AFD0A94FC52C3B28FF457E81C12A89A /* PBXTargetDependency */ = {
+		550881E247A6490F4BE30E629D3C799D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ZettaKit;
+			target = 805C72C34E25E78947F6F6DAEE4C43CE /* ZettaKit */;
+			targetProxy = 9F324B4A9CB1F5429EB2D100B8F2FF4B /* PBXContainerItemProxy */;
+		};
+		575688E5B062A82D6FA4C7C20B0287B4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Expecta;
-			target = D5822815B54870852F7739B671476F97 /* Expecta */;
-			targetProxy = FD96B09BE96174807A2E56EBCC88E0A6 /* PBXContainerItemProxy */;
+			target = 2F501FE84845EAD97B9087DAFCBBEE0E /* Expecta */;
+			targetProxy = 686D9A35CDF6D2B2162AB96D38861998 /* PBXContainerItemProxy */;
 		};
-		D0EB9CBBB67A682C9BF2E5169FE5BB3C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ReactiveCocoa;
-			target = D3A64ECCCBFFF840589B13BDEC5658CA /* ReactiveCocoa */;
-			targetProxy = DE4F913778A48FEBF92C9A97E10CDFC6 /* PBXContainerItemProxy */;
-		};
-		D5C04E8B886C831F3604E129E5D50136 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Specta;
-			target = E97A02DD69143CF53448FEACFEE09AEF /* Specta */;
-			targetProxy = E2C616F35B5E594FDB000398E3710716 /* PBXContainerItemProxy */;
-		};
-		D9338291CEA80BD13BB4370FF37DBA3F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ReactiveCocoa;
-			target = D3A64ECCCBFFF840589B13BDEC5658CA /* ReactiveCocoa */;
-			targetProxy = 1FB56A8F48A216603038CA7A269EC5EF /* PBXContainerItemProxy */;
-		};
-		E2B005FAE403468C0695BF666248979C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ZettaKit-ZettaKit";
-			target = 37E21E3BEC55210F96E0E70DD1D5C67F /* ZettaKit-ZettaKit */;
-			targetProxy = 9AF2B4F6BAFDC4E6A99EA5E2EAF55AD7 /* PBXContainerItemProxy */;
-		};
-		F1226800D89C49313DFD91D34A7FB8F7 /* PBXTargetDependency */ = {
+		A2A18D43B5414F4716587F00AE3DA833 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ZettaKit;
-			target = E3BBC7436BFB11CEA6FEA7154092CCE5 /* ZettaKit */;
-			targetProxy = F4CE0B32AA678F963166273E01AE0B47 /* PBXContainerItemProxy */;
+			target = 805C72C34E25E78947F6F6DAEE4C43CE /* ZettaKit */;
+			targetProxy = ED711062B0B5544BE011F88C82107176 /* PBXContainerItemProxy */;
+		};
+		B3AE346EAD3FBAC9E895728092990D0B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SocketRocket;
+			target = 3A1177A0BC321ECAB30C8B49CFFCBDFB /* SocketRocket */;
+			targetProxy = 8D1E0362EE9529D78DFB73B60EAC629C /* PBXContainerItemProxy */;
+		};
+		BFB584ABE78AFA9932F71E341D318626 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ZettaKit-ZettaKit";
+			target = ABBB78DB01D7200F26A57501800026B0 /* ZettaKit-ZettaKit */;
+			targetProxy = 6617CC05BD5AFCB674D267B7A022F001 /* PBXContainerItemProxy */;
+		};
+		C8F104523B8165837572BECE15FCA0BC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Specta;
+			target = C656B1062EF5478BD86D177C779AD322 /* Specta */;
+			targetProxy = 0B8101B59577FD0FF51309759D84F21B /* PBXContainerItemProxy */;
+		};
+		CF83A0B670988CE36B4C34976C1103AF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ReactiveCocoa;
+			target = EFBF56E35BBB16C86D5BE5D8756EFF7B /* ReactiveCocoa */;
+			targetProxy = A63E88A25D0AA0750ACA87BC70F7295B /* PBXContainerItemProxy */;
+		};
+		CFD6BF580C6BFBDE03C9CEB514DDD0E4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SocketRocket;
+			target = 3A1177A0BC321ECAB30C8B49CFFCBDFB /* SocketRocket */;
+			targetProxy = 89F5D3F36FD54E85BF4B82D382D2E3C9 /* PBXContainerItemProxy */;
+		};
+		DD8EA70F514F33583A609F3B2B7CD842 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ReactiveCocoa;
+			target = EFBF56E35BBB16C86D5BE5D8756EFF7B /* ReactiveCocoa */;
+			targetProxy = 4B5F08533225606C35FE1B0AAD7BB4B6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		03B42CF1C56A584D6682B514C896F23E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 42751639AEB7DB107D3E464F4F222E89 /* Pods-Tests.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MACH_O_TYPE = staticlib;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		03CA91998D6773EC5D02B3DB87B8353E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2219,34 +2238,6 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
-		};
-		079B713B0340C3D388DA1F52CFD164BF /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 91392DE38B4FB4739B17385406654308 /* ZettaKit-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				PRODUCT_NAME = ZettaKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
-		08E89D331E03EBF182538268F240957A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B650A7A6BCA23719411AA89674431D23 /* Pods-Tests.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
 		};
 		0B57334D6C23DADAA4F7D802A5760EB2 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2287,41 +2278,27 @@
 			};
 			name = Debug;
 		};
-		167C7F03EEB592C7F27283FE90B3AAAC /* Debug */ = {
+		1533B69122592B19CE347FF5D387E634 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C30AC3FDD2C139ADCA631E07F6E8FE17 /* Specta-Private.xcconfig */;
+			baseConfigurationReference = F3E111D4C089C0A31503E716B65AA779 /* Expecta.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
-		1E821563DE0D52CEFFE41200021258EA /* Release */ = {
+		2B1CE4F8CC8DF3E71914C4BEAE7D470C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 93F2B074CCCBC677B8AC5242D459C20C /* SocketRocket-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		250B9D18AC7344650854B5D0CCB10641 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 72C0552B5CD20267E4FC7A385C657EF7 /* ReactiveCocoa-Private.xcconfig */;
+			baseConfigurationReference = 45108978875126195B31FE2DFBEBE629 /* ReactiveCocoa.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/ReactiveCocoa/ReactiveCocoa-prefix.pch";
@@ -2329,51 +2306,22 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
-		57A99162BA697A65BC804DBC9DC650A0 /* Debug */ = {
+		485D632736DCDC804D689BA7D4D23E0A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 93F2B074CCCBC677B8AC5242D459C20C /* SocketRocket-Private.xcconfig */;
+			baseConfigurationReference = B06C9DB1C4CBEDD9663F665AFD3E0335 /* Pods-ZettaKit.debug.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		6096237C50B041D0EF378364C1EEB75B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C30AC3FDD2C139ADCA631E07F6E8FE17 /* Specta-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		7BE27AFB23F2E5CA5E5F2039D0AB46E0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = EC1C002644E52229F4C9680EDF9B78B2 /* Pods-ZettaKit.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
@@ -2381,11 +2329,11 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
-			name = Release;
+			name = Debug;
 		};
-		7C61AB7A0F01C837E381A4D413ADEABA /* Debug */ = {
+		5C049CAC75FEFD6B3A32EC2EC755FBB9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 91392DE38B4FB4739B17385406654308 /* ZettaKit-Private.xcconfig */;
+			baseConfigurationReference = F77F8C85983D53E4908475A4607D3634 /* ZettaKit.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/ZettaKit/ZettaKit-prefix.pch";
@@ -2393,15 +2341,124 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5E27D8F286CEC609CD8E93B8ABEB4245 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 48B82B750F17D002C4520D18CB7F5371 /* SocketRocket.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		65097F14481450EFCFC10451BB67FD1C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45108978875126195B31FE2DFBEBE629 /* ReactiveCocoa.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/ReactiveCocoa/ReactiveCocoa-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		73A0B35204C1AFABC17A0C9CB815C734 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F3E111D4C089C0A31503E716B65AA779 /* Expecta.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		7B05E8E3486868B755C848BA7AF0A835 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6CDF80664B47D8E9EAA9B0A72C90C372 /* Pods-Tests.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MACH_O_TYPE = staticlib;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
-		99ADE6CB9A30EA8EB1DCE6A3CE6BAC32 /* Debug */ = {
+		8D1B1F6A1DCCFB5CB2B5A1000347A0AA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 91392DE38B4FB4739B17385406654308 /* ZettaKit-Private.xcconfig */;
+			baseConfigurationReference = 48B82B750F17D002C4520D18CB7F5371 /* SocketRocket.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		9DD91328D2A6AC171AF209DF57C07440 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5FF282FE24CC88B4329AEB0A042963DF /* Specta.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		A23C62B445B315F4584286043EF1CAEF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F77F8C85983D53E4908475A4607D3634 /* ZettaKit.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				PRODUCT_NAME = ZettaKit;
@@ -2411,41 +2468,56 @@
 			};
 			name = Debug;
 		};
-		9BE22AE83C1AD09B6078FF5CD0CF0420 /* Debug */ = {
+		A30363663CE4B6885E313BE2224E6A12 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 72C0552B5CD20267E4FC7A385C657EF7 /* ReactiveCocoa-Private.xcconfig */;
+			baseConfigurationReference = D215B9F08998FEE6B350456C4A96BBE4 /* Pods-ZettaKit.release.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/ReactiveCocoa/ReactiveCocoa-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MACH_O_TYPE = staticlib;
+				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
-			name = Debug;
+			name = Release;
 		};
-		ADE8B1498B62A7DCB09E7025E72A9404 /* Debug */ = {
+		A5C55DDA8989F0B156ED370D94322448 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 57876C1F28D0C180023DCBB0276C81C0 /* Expecta-Private.xcconfig */;
+			baseConfigurationReference = 5FF282FE24CC88B4329AEB0A042963DF /* Specta.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
-			name = Debug;
+			name = Release;
 		};
-		B141EA4596CB7CC3E6AD50790CF53E1C /* Release */ = {
+		D71FF7EF5B47987BB3C344352AC37098 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 91392DE38B4FB4739B17385406654308 /* ZettaKit-Private.xcconfig */;
+			baseConfigurationReference = F77F8C85983D53E4908475A4607D3634 /* ZettaKit.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = ZettaKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		EC93B5CC7D8586399A39CD762A161515 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F77F8C85983D53E4908475A4607D3634 /* ZettaKit.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/ZettaKit/ZettaKit-prefix.pch";
@@ -2453,55 +2525,9 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		C7C491083E017C58A29289DD3B7B385C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E74D0C31F5F73E957FDE559E55E40808 /* Pods-Tests.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		D29288CFA053579435B734DBCDB52FCD /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 50CAB6E112050E908BCE5A95DBBAE81A /* Pods-ZettaKit.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		D40C1F639696AB4F9ADBBEB697AAF357 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 57876C1F28D0C180023DCBB0276C81C0 /* Expecta-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
@@ -2510,15 +2536,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0A75FC6597F46D32F61F86B010D02A27 /* Build configuration list for PBXNativeTarget "SocketRocket" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				57A99162BA697A65BC804DBC9DC650A0 /* Debug */,
-				1E821563DE0D52CEFFE41200021258EA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2528,65 +2545,74 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5DE37D97A94548C93B4798A701D6E6CE /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
+		3D0724F00C90AA674A07DF04E36684B2 /* Build configuration list for PBXNativeTarget "Pods-ZettaKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				08E89D331E03EBF182538268F240957A /* Debug */,
-				C7C491083E017C58A29289DD3B7B385C /* Release */,
+				485D632736DCDC804D689BA7D4D23E0A /* Debug */,
+				A30363663CE4B6885E313BE2224E6A12 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5E726641067B8ACCD49E86227C2E5F41 /* Build configuration list for PBXNativeTarget "Specta" */ = {
+		48F150BE39F613AD1D658067A0762423 /* Build configuration list for PBXNativeTarget "ReactiveCocoa" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				167C7F03EEB592C7F27283FE90B3AAAC /* Debug */,
-				6096237C50B041D0EF378364C1EEB75B /* Release */,
+				65097F14481450EFCFC10451BB67FD1C /* Debug */,
+				2B1CE4F8CC8DF3E71914C4BEAE7D470C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		897D4DFC2660D5DE9C5C80054988C1DD /* Build configuration list for PBXNativeTarget "ZettaKit-ZettaKit" */ = {
+		57205495CF13B4EE93B13B7B0E3A1BD2 /* Build configuration list for PBXNativeTarget "Expecta" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				99ADE6CB9A30EA8EB1DCE6A3CE6BAC32 /* Debug */,
-				079B713B0340C3D388DA1F52CFD164BF /* Release */,
+				1533B69122592B19CE347FF5D387E634 /* Debug */,
+				73A0B35204C1AFABC17A0C9CB815C734 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A9E1BFC8ACF1ED450E74A705819D3AF9 /* Build configuration list for PBXNativeTarget "Pods-ZettaKit" */ = {
+		592BAC1C465F11BCCE9A7A8934A2A2B7 /* Build configuration list for PBXNativeTarget "SocketRocket" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D29288CFA053579435B734DBCDB52FCD /* Debug */,
-				7BE27AFB23F2E5CA5E5F2039D0AB46E0 /* Release */,
+				8D1B1F6A1DCCFB5CB2B5A1000347A0AA /* Debug */,
+				5E27D8F286CEC609CD8E93B8ABEB4245 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B7916E61BC726ABF0726190528FC81F8 /* Build configuration list for PBXNativeTarget "ReactiveCocoa" */ = {
+		771C434F1279152CF0D48396CB9066A0 /* Build configuration list for PBXNativeTarget "ZettaKit-ZettaKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9BE22AE83C1AD09B6078FF5CD0CF0420 /* Debug */,
-				250B9D18AC7344650854B5D0CCB10641 /* Release */,
+				A23C62B445B315F4584286043EF1CAEF /* Debug */,
+				D71FF7EF5B47987BB3C344352AC37098 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FB534589569CDA5BD50DAFFC869C3722 /* Build configuration list for PBXNativeTarget "ZettaKit" */ = {
+		825DF432813611D8327F1D2ACDBB1482 /* Build configuration list for PBXNativeTarget "ZettaKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7C61AB7A0F01C837E381A4D413ADEABA /* Debug */,
-				B141EA4596CB7CC3E6AD50790CF53E1C /* Release */,
+				5C049CAC75FEFD6B3A32EC2EC755FBB9 /* Debug */,
+				EC93B5CC7D8586399A39CD762A161515 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FDBA6E19D31B9E8B9D71609F10454540 /* Build configuration list for PBXNativeTarget "Expecta" */ = {
+		A2F015C9A1FAC858E60CD24132B428F7 /* Build configuration list for PBXNativeTarget "Specta" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				ADE8B1498B62A7DCB09E7025E72A9404 /* Debug */,
-				D40C1F639696AB4F9ADBBEB697AAF357 /* Release */,
+				9DD91328D2A6AC171AF209DF57C07440 /* Debug */,
+				A5C55DDA8989F0B156ED370D94322448 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C4B199C0596B8AD888F87AC19CF7D9B2 /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7B05E8E3486868B755C848BA7AF0A835 /* Debug */,
+				03B42CF1C56A584D6682B514C896F23E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/ZettaKit.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/ZettaKit.xcscheme
@@ -7,17 +7,17 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForArchiving = "YES">
             <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "434563F8829D24A3B50E837F"
-               BuildableName = "libZettaKit.a"
-               BlueprintName = "ZettaKit"
-               ReferencedContainer = "container:Pods.xcodeproj">
+               BuildableIdentifier = 'primary'
+               BlueprintIdentifier = '551A5594D3E39AC4D8AA2CEC'
+               BlueprintName = 'ZettaKit'
+               ReferencedContainer = 'container:Pods.xcodeproj'
+               BuildableName = 'libZettaKit.a'>
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -29,28 +29,26 @@
       buildConfiguration = "Debug">
       <AdditionalOptions>
       </AdditionalOptions>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
       buildConfiguration = "Release"
-      debugDocumentVersioning = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Pods/Target Support Files/Expecta/Expecta-Private.xcconfig
+++ b/Example/Pods/Target Support Files/Expecta/Expecta-Private.xcconfig
@@ -1,8 +1,0 @@
-#include "Expecta.xcconfig"
-ENABLE_BITCODE = ${EXPECTA_ENABLE_BITCODE}
-FRAMEWORK_SEARCH_PATHS = ${EXPECTA_FRAMEWORK_SEARCH_PATHS}
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/Expecta" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
-OTHER_LDFLAGS = ${EXPECTA_OTHER_LDFLAGS}
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/Expecta/Expecta.xcconfig
+++ b/Example/Pods/Target Support Files/Expecta/Expecta.xcconfig
@@ -1,3 +1,7 @@
-EXPECTA_ENABLE_BITCODE = NO
-EXPECTA_FRAMEWORK_SEARCH_PATHS = $(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-EXPECTA_OTHER_LDFLAGS = -framework "Foundation" -framework "XCTest"
+ENABLE_BITCODE = NO
+FRAMEWORK_SEARCH_PATHS = $(inherited)  "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/Expecta" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
+OTHER_LDFLAGS = -framework "Foundation" -framework "XCTest"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh
+++ b/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+SWIFT_STDLIB_PATH="${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
+
+install_framework()
+{
+  if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$1"
+  elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$(basename "$1")"
+  elif [ -r "$1" ]; then
+    local source="$1"
+  fi
+
+  local destination="${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+  if [ -L "${source}" ]; then
+      echo "Symlinked..."
+      source="$(readlink "${source}")"
+  fi
+
+  # use filter instead of exclude so missing patterns dont' throw errors
+  echo "rsync -av --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${source}\" \"${destination}\""
+  rsync -av --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${destination}"
+
+  local basename
+  basename="$(basename -s .framework "$1")"
+  binary="${destination}/${basename}.framework/${basename}"
+  if ! [ -r "$binary" ]; then
+    binary="${destination}/${basename}"
+  fi
+
+  # Strip invalid architectures so "fat" simulator / device frameworks work on device
+  if [[ "$(file "$binary")" == *"dynamically linked shared library"* ]]; then
+    strip_invalid_archs "$binary"
+  fi
+
+  # Resign the code if required by the build settings to avoid unstable apps
+  code_sign_if_enabled "${destination}/$(basename "$1")"
+
+  # Embed linked Swift runtime libraries. No longer necessary as of Xcode 7.
+  if [ "${XCODE_VERSION_MAJOR}" -lt 7 ]; then
+    local swift_runtime_libs
+    swift_runtime_libs=$(xcrun otool -LX "$binary" | grep --color=never @rpath/libswift | sed -E s/@rpath\\/\(.+dylib\).*/\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
+    for lib in $swift_runtime_libs; do
+      echo "rsync -auv \"${SWIFT_STDLIB_PATH}/${lib}\" \"${destination}\""
+      rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
+      code_sign_if_enabled "${destination}/${lib}"
+    done
+  fi
+}
+
+# Signs a framework with the provided identity
+code_sign_if_enabled() {
+  if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
+    # Use the current code_sign_identitiy
+    echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
+    echo "/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\""
+    /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$1"
+  fi
+}
+
+# Strip invalid architectures
+strip_invalid_archs() {
+  binary="$1"
+  # Get architectures for current file
+  archs="$(lipo -info "$binary" | rev | cut -d ':' -f1 | rev)"
+  stripped=""
+  for arch in $archs; do
+    if ! [[ "${VALID_ARCHS}" == *"$arch"* ]]; then
+      # Strip non-valid architectures in-place
+      lipo -remove "$arch" -output "$binary" "$binary" || exit 1
+      stripped="$stripped $arch"
+    fi
+  done
+  if [[ "$stripped" ]]; then
+    echo "Stripped $binary of architectures:$stripped"
+  fi
+}
+

--- a/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh
+++ b/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh
@@ -66,7 +66,7 @@ fi
 
 mkdir -p "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
-if [[ "${ACTION}" == "install" ]]; then
+if [[ "${ACTION}" == "install" ]] && [[ "${SKIP_INSTALL}" == "NO" ]]; then
   mkdir -p "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 fi

--- a/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig
+++ b/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig
@@ -1,5 +1,4 @@
-ENABLE_BITCODE = NO
-FRAMEWORK_SEARCH_PATHS = $(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+FRAMEWORK_SEARCH_PATHS = $(inherited)  "$(PLATFORM_DIR)/Developer/Library/Frameworks"
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
 HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
 OTHER_CFLAGS = $(inherited) -isystem "${PODS_ROOT}/Headers/Public" -isystem "${PODS_ROOT}/Headers/Public/Expecta" -isystem "${PODS_ROOT}/Headers/Public/ReactiveCocoa" -isystem "${PODS_ROOT}/Headers/Public/SocketRocket" -isystem "${PODS_ROOT}/Headers/Public/Specta" -isystem "${PODS_ROOT}/Headers/Public/ZettaKit"

--- a/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig
+++ b/Example/Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig
@@ -1,5 +1,4 @@
-ENABLE_BITCODE = NO
-FRAMEWORK_SEARCH_PATHS = $(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+FRAMEWORK_SEARCH_PATHS = $(inherited)  "$(PLATFORM_DIR)/Developer/Library/Frameworks"
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
 HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
 OTHER_CFLAGS = $(inherited) -isystem "${PODS_ROOT}/Headers/Public" -isystem "${PODS_ROOT}/Headers/Public/Expecta" -isystem "${PODS_ROOT}/Headers/Public/ReactiveCocoa" -isystem "${PODS_ROOT}/Headers/Public/SocketRocket" -isystem "${PODS_ROOT}/Headers/Public/Specta" -isystem "${PODS_ROOT}/Headers/Public/ZettaKit"

--- a/Example/Pods/Target Support Files/Pods-ZettaKit/Pods-ZettaKit-frameworks.sh
+++ b/Example/Pods/Target Support Files/Pods-ZettaKit/Pods-ZettaKit-frameworks.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+SWIFT_STDLIB_PATH="${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
+
+install_framework()
+{
+  if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$1"
+  elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then
+    local source="${BUILT_PRODUCTS_DIR}/$(basename "$1")"
+  elif [ -r "$1" ]; then
+    local source="$1"
+  fi
+
+  local destination="${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+  if [ -L "${source}" ]; then
+      echo "Symlinked..."
+      source="$(readlink "${source}")"
+  fi
+
+  # use filter instead of exclude so missing patterns dont' throw errors
+  echo "rsync -av --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${source}\" \"${destination}\""
+  rsync -av --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${destination}"
+
+  local basename
+  basename="$(basename -s .framework "$1")"
+  binary="${destination}/${basename}.framework/${basename}"
+  if ! [ -r "$binary" ]; then
+    binary="${destination}/${basename}"
+  fi
+
+  # Strip invalid architectures so "fat" simulator / device frameworks work on device
+  if [[ "$(file "$binary")" == *"dynamically linked shared library"* ]]; then
+    strip_invalid_archs "$binary"
+  fi
+
+  # Resign the code if required by the build settings to avoid unstable apps
+  code_sign_if_enabled "${destination}/$(basename "$1")"
+
+  # Embed linked Swift runtime libraries. No longer necessary as of Xcode 7.
+  if [ "${XCODE_VERSION_MAJOR}" -lt 7 ]; then
+    local swift_runtime_libs
+    swift_runtime_libs=$(xcrun otool -LX "$binary" | grep --color=never @rpath/libswift | sed -E s/@rpath\\/\(.+dylib\).*/\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
+    for lib in $swift_runtime_libs; do
+      echo "rsync -auv \"${SWIFT_STDLIB_PATH}/${lib}\" \"${destination}\""
+      rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
+      code_sign_if_enabled "${destination}/${lib}"
+    done
+  fi
+}
+
+# Signs a framework with the provided identity
+code_sign_if_enabled() {
+  if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
+    # Use the current code_sign_identitiy
+    echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
+    echo "/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\""
+    /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$1"
+  fi
+}
+
+# Strip invalid architectures
+strip_invalid_archs() {
+  binary="$1"
+  # Get architectures for current file
+  archs="$(lipo -info "$binary" | rev | cut -d ':' -f1 | rev)"
+  stripped=""
+  for arch in $archs; do
+    if ! [[ "${VALID_ARCHS}" == *"$arch"* ]]; then
+      # Strip non-valid architectures in-place
+      lipo -remove "$arch" -output "$binary" "$binary" || exit 1
+      stripped="$stripped $arch"
+    fi
+  done
+  if [[ "$stripped" ]]; then
+    echo "Stripped $binary of architectures:$stripped"
+  fi
+}
+

--- a/Example/Pods/Target Support Files/Pods-ZettaKit/Pods-ZettaKit-resources.sh
+++ b/Example/Pods/Target Support Files/Pods-ZettaKit/Pods-ZettaKit-resources.sh
@@ -66,7 +66,7 @@ fi
 
 mkdir -p "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
-if [[ "${ACTION}" == "install" ]]; then
+if [[ "${ACTION}" == "install" ]] && [[ "${SKIP_INSTALL}" == "NO" ]]; then
   mkdir -p "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 fi

--- a/Example/Pods/Target Support Files/ReactiveCocoa/ReactiveCocoa-Private.xcconfig
+++ b/Example/Pods/Target Support Files/ReactiveCocoa/ReactiveCocoa-Private.xcconfig
@@ -1,5 +1,0 @@
-#include "ReactiveCocoa.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveCocoa" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/ReactiveCocoa/ReactiveCocoa.xcconfig
+++ b/Example/Pods/Target Support Files/ReactiveCocoa/ReactiveCocoa.xcconfig
@@ -1,0 +1,4 @@
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ReactiveCocoa" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/SocketRocket/SocketRocket-Private.xcconfig
+++ b/Example/Pods/Target Support Files/SocketRocket/SocketRocket-Private.xcconfig
@@ -1,6 +1,0 @@
-#include "SocketRocket.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/SocketRocket" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
-OTHER_LDFLAGS = ${SOCKETROCKET_OTHER_LDFLAGS}
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/SocketRocket/SocketRocket.xcconfig
+++ b/Example/Pods/Target Support Files/SocketRocket/SocketRocket.xcconfig
@@ -1,1 +1,5 @@
-SOCKETROCKET_OTHER_LDFLAGS = -l"icucore" -framework "CFNetwork" -framework "Security"
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/SocketRocket" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
+OTHER_LDFLAGS = -l"icucore" -framework "CFNetwork" -framework "Security"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/Specta/Specta-Private.xcconfig
+++ b/Example/Pods/Target Support Files/Specta/Specta-Private.xcconfig
@@ -1,8 +1,0 @@
-#include "Specta.xcconfig"
-ENABLE_BITCODE = ${SPECTA_ENABLE_BITCODE}
-FRAMEWORK_SEARCH_PATHS = ${SPECTA_FRAMEWORK_SEARCH_PATHS}
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/Specta" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
-OTHER_LDFLAGS = ${SPECTA_OTHER_LDFLAGS}
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/Specta/Specta.xcconfig
+++ b/Example/Pods/Target Support Files/Specta/Specta.xcconfig
@@ -1,3 +1,7 @@
-SPECTA_ENABLE_BITCODE = NO
-SPECTA_FRAMEWORK_SEARCH_PATHS = $(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-SPECTA_OTHER_LDFLAGS = -framework "Foundation" -framework "XCTest"
+ENABLE_BITCODE = NO
+FRAMEWORK_SEARCH_PATHS = $(inherited)  "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/Specta" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
+OTHER_LDFLAGS = -framework "Foundation" -framework "XCTest"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/ZettaKit/ZettaKit-Private.xcconfig
+++ b/Example/Pods/Target Support Files/ZettaKit/ZettaKit-Private.xcconfig
@@ -1,6 +1,0 @@
-#include "ZettaKit.xcconfig"
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ZettaKit" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
-OTHER_LDFLAGS = ${ZETTAKIT_OTHER_LDFLAGS}
-PODS_ROOT = ${SRCROOT}
-SKIP_INSTALL = YES

--- a/Example/Pods/Target Support Files/ZettaKit/ZettaKit.xcconfig
+++ b/Example/Pods/Target Support Files/ZettaKit/ZettaKit.xcconfig
@@ -1,1 +1,5 @@
-ZETTAKIT_OTHER_LDFLAGS = -l"z"
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/ZettaKit" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Expecta" "${PODS_ROOT}/Headers/Public/ReactiveCocoa" "${PODS_ROOT}/Headers/Public/SocketRocket" "${PODS_ROOT}/Headers/Public/Specta" "${PODS_ROOT}/Headers/Public/ZettaKit"
+OTHER_LDFLAGS = -l"z"
+PODS_ROOT = ${SRCROOT}
+SKIP_INSTALL = YES

--- a/Example/Tests/ZIKQueryTests.m
+++ b/Example/Tests/ZIKQueryTests.m
@@ -1,0 +1,74 @@
+//
+//  ZIKQueryTests.m
+//  ZettaKit
+//
+//  Created by Matthew Dobson on 2/23/16.
+//  Copyright © 2016 Matthew Dobson. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ZIKQuery.h"
+
+SpecBegin(ZIKQuery)
+
+NSDictionary *data = @{
+                       @"class":@[@"server"],
+                       @"properties":@{
+                               @"name":@"cloud"
+                               },
+                       @"entities":@[],
+                       @"actions":@[
+                               @{
+                                   @"name":@"query-devices",
+                                   @"method":@"GET",
+                                   @"href":@"http://zetta-cloud-2.herokuapp.com/servers/cloud",
+                                   @"type":@"application/x-www-form-urlencoded",
+                                   @"fields":@[
+                                           @{
+                                               @"name":@"ql",
+                                               @"type":@"text"
+                                               }
+                                           ]
+                                   }],
+                       @"links":@[
+                               @{
+                                   @"rel":@[@"self"],
+                                   @"href":@"http://zetta-cloud-2.herokuapp.com/servers/cloud"
+                                   },@{
+                                   @"rel":@[@"http://rels.zettajs.io/metadata"],
+                                   @"href":@"http://zetta-cloud-2.herokuapp.com/servers/cloud/meta"
+                                   },
+                               @{
+                                   @"rel":@[@"monitor"],
+                                   @"href":@"ws://zetta-cloud-2.herokuapp.com/servers/cloud/events?topic=logs"
+                                   }
+                               ]
+                       };
+
+describe(@"ZIKQuery", ^{
+   it(@"Will initialize to a set server and ql", ^{
+       ZIKQuery *query = [ZIKQuery queryFromString:@"where type = \"foo\"" fromServer:[ZIKServer initWithDictionary:data]];
+       expect(query.server.name).to.equal(@"cloud");
+       expect(query.query).to.equal(@"where type = \"foo\"");
+   });
+    
+    it(@"Will query all servers", ^{
+        ZIKQuery *query = [ZIKQuery queryFromStringOnAllServers:@"where type = \"foo\""];
+        expect(query.server.name).to.equal(@"*");
+        expect(query.query).to.equal(@"where type = \"foo\"");
+    });
+    
+    it(@"Will query all devices", ^{
+        ZIKQuery *query = [ZIKQuery allDevicesFromServer:[ZIKServer initWithDictionary:data]];
+        expect(query.query).to.equal(@"where type is not none");
+        expect(query.server.name).to.equal(@"cloud");
+    });
+    
+    it(@"Will query for all devices and query all servers", ^{
+        ZIKQuery *query = [ZIKQuery allDevicesFromAllServers];
+        expect(query.query).to.equal(@"where type is not none");
+        expect(query.server.name).to.equal(@"*");
+    });
+});
+
+SpecEnd

--- a/Example/ZettaKit.xcodeproj/project.pbxproj
+++ b/Example/ZettaKit.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		F55650421ADEB13300EE2E2B /* ZIKDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F55650411ADEB13300EE2E2B /* ZIKDeviceTests.m */; };
 		F5B64E8B1B87860C004A556D /* EndpointViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5B64E8A1B87860C004A556D /* EndpointViewController.m */; };
 		F5D382AA1C6128A500CCEB3E /* ZIKStreamTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5D382A91C6128A500CCEB3E /* ZIKStreamTests.m */; };
+		F5E041821C7CFBA500411377 /* ZIKQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5E041811C7CFBA500411377 /* ZIKQueryTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +95,7 @@
 		F5B64E891B87860C004A556D /* EndpointViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EndpointViewController.h; sourceTree = "<group>"; };
 		F5B64E8A1B87860C004A556D /* EndpointViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EndpointViewController.m; sourceTree = "<group>"; };
 		F5D382A91C6128A500CCEB3E /* ZIKStreamTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZIKStreamTests.m; sourceTree = "<group>"; };
+		F5E041811C7CFBA500411377 /* ZIKQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZIKQueryTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +206,7 @@
 				F51C9A271AE0270E004BC6FA /* ZIKUtilTests.m */,
 				F51C9A291AE050A0004BC6FA /* ZIKTransitionTests.m */,
 				F5D382A91C6128A500CCEB3E /* ZIKStreamTests.m */,
+				F5E041811C7CFBA500411377 /* ZIKQueryTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -454,6 +457,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F5D382AA1C6128A500CCEB3E /* ZIKStreamTests.m in Sources */,
+				F5E041821C7CFBA500411377 /* ZIKQueryTests.m in Sources */,
 				F51C9A281AE0270E004BC6FA /* ZIKUtilTests.m in Sources */,
 				F51C9A141AE01EAB004BC6FA /* ZIKLinkTests.m in Sources */,
 				F55650421ADEB13300EE2E2B /* ZIKDeviceTests.m in Sources */,

--- a/Example/ZettaKit.xcodeproj/project.pbxproj
+++ b/Example/ZettaKit.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
 				13CF8955E7BF0B5178057431 /* Copy Pods Resources */,
+				A2D6253FA0E525F11FE14788 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -270,6 +271,7 @@
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
 				D215AACBB44B8E46356CDE1E /* Copy Pods Resources */,
+				D5DC83C188E8F5D4FFCEA5FE /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -368,6 +370,21 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		A2D6253FA0E525F11FE14788 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ZettaKit/Pods-ZettaKit-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		D215AACBB44B8E46356CDE1E /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -381,6 +398,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D5DC83C188E8F5D4FFCEA5FE /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8FD82F725F4ABD435693000 /* Check Pods Manifest.lock */ = {

--- a/Example/ZettaKit/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/ZettaKit/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",
@@ -16,6 +26,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
       "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
@@ -43,6 +58,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/Pod/Classes/ZIKLogStreamEntry.h
+++ b/Pod/Classes/ZIKLogStreamEntry.h
@@ -50,6 +50,11 @@
  */
 @property (nonatomic, retain, readonly) NSString *deviceState;
 
+/**
+ The inputs to the transition.
+ */
+@property (nonatomic, retain, readonly) NSDictionary *inputs;
+
 ///---------------------------
 /// @name Initialization
 ///---------------------------

--- a/Pod/Classes/ZIKLogStreamEntry.m
+++ b/Pod/Classes/ZIKLogStreamEntry.m
@@ -32,6 +32,7 @@
 @property (nonatomic, retain, readwrite) NSNumber *timestamp;
 @property (nonatomic, retain, readwrite) NSString *transition;
 @property (nonatomic, retain, readwrite) NSString *deviceState;
+@property (nonatomic, retain, readwrite) NSDictionary *inputs;
 
 @end
 
@@ -44,6 +45,12 @@
         NSDictionary *properties = data[@"properties"];
         self.deviceState = properties[@"state"];
         self.transition = data[@"transition"];
+        
+        if(data[@"inputs"]) {
+            self.inputs = data[@"inputs"];
+        } else {
+            self.inputs = @{};
+        }
     }
     return self;
 }

--- a/Pod/Classes/ZIKQuery.h
+++ b/Pod/Classes/ZIKQuery.h
@@ -58,6 +58,31 @@
 + (instancetype) queryFromString:(NSString *)query fromServer:(ZIKServer *)server;
 
 /**
+ Initializes a `ZIKQuery` to find all devices with the specified `ZIKServer` object.
+ 
+ @param server The server to perform the query on.
+ 
+ @return The newly-initialized `ZIKQuery` object.
+ */
++ (instancetype) allDevicesFromServer:(ZIKServer *)server;
+
+/**
+ Initializes a `ZIKQuery` to find all devices on all servers.
+ 
+ @return The newly-initialized `ZIKQuery` object.
+ */
++ (instancetype) allDevicesFromAllServers;
+
+/**
+ Initializes a `ZIKQuery` with the specified query to run on all servers.
+ 
+ @param query The base CAQL query used to filter devices.
+ 
+ @return The newly-initialized `ZIKQuery` object.
+ */
++ (instancetype) queryFromStringOnAllServers:(NSString *)query;
+
+/**
  Initializes a `ZIKQuery` with the specified query and `ZIKServer` object.
  
  @param query The base CAQL query used to filter devices.

--- a/Pod/Classes/ZIKQuery.m
+++ b/Pod/Classes/ZIKQuery.m
@@ -39,6 +39,22 @@
     return [[ZIKQuery alloc] initWithQuery:query andServer:server];
 }
 
++ (instancetype) allDevicesFromServer:(ZIKServer *)server {
+    return [[ZIKQuery alloc] initWithQuery:@"where type is not none" andServer:server];
+}
+
++ (instancetype) allDevicesFromAllServers {
+    NSDictionary *data = @{@"properties": @{@"name": @"*"}, @"entities": @[], @"links": @[]};
+    ZIKServer *server = [ZIKServer initWithDictionary:data];
+    return [[ZIKQuery alloc] initWithQuery:@"where type is not none" andServer:server];
+}
+
++ (instancetype) queryFromStringOnAllServers:(NSString *)query {
+    NSDictionary *data = @{@"properties": @{@"name": @"*"}, @"entities": @[], @"links": @[]};
+    ZIKServer *server = [ZIKServer initWithDictionary:data];
+    return [[ZIKQuery alloc] initWithQuery:query andServer:server];
+}
+
 - (instancetype) initWithQuery:(NSString *)query andServer:(ZIKServer *)server {
     if (self = [super init]) {
         self.query = query;

--- a/Pod/Classes/ZIKQueryResponse.h
+++ b/Pod/Classes/ZIKQueryResponse.h
@@ -12,14 +12,57 @@
 
 @interface ZIKQueryResponse : NSObject
 
+/**
+ Links included with the query response.
+ */
 @property (nonatomic, retain, readonly) NSArray *links;
+
+/**
+ The devices that fulfill the query.
+ */
 @property (nonatomic, retain) NSArray *devices;
+
+/**
+ The server the query was executed against.
+ */
 @property (nonatomic, retain, readonly) NSString *server;
+
+/**
+ The CAQL query language used to filter devices.
+ */
 @property (nonatomic, retain,readonly) NSString *ql;
 
+///---------------------------
+/// @name Initialization
+///---------------------------
+
+/**
+ Initializes a `ZIKQueryResponse` with the specified websocket document in `NSDictionary` form.
+ 
+ @param data The base siren document to create the stream entry with.
+ 
+ @return The newly-initialized `ZIKQueryResponse` object.
+ */
+
 -(instancetype) initWithDictionary:(NSDictionary *) data;
+
+/**
+ Initializes a `ZIKQueryResponse` with the specified websocket document in `NSDictionary` form.
+ 
+ This is the designated initializer.
+ 
+ @param data The base siren document to create the stream entry with.
+ 
+ @return The newly-initialized `ZIKQueryResponse` object.
+ */
+
 +(instancetype) initWithDictionary:(NSDictionary *) data;
 
+/**
+ Creates a `ZIKStream` of results.
+ 
+ @return `ZIKStream` that will update with devices that fulfill the query.
+ */
 -(ZIKStream *) resultsStream;
 
 @end

--- a/Pod/Classes/ZIKQueryResponse.h
+++ b/Pod/Classes/ZIKQueryResponse.h
@@ -1,0 +1,25 @@
+//
+//  ZIKQueryResponse.h
+//  Pods
+//
+//  Created by Matthew Dobson on 2/17/16.
+//
+//
+
+#import "ZIKStream.h"
+
+#import <Foundation/Foundation.h>
+
+@interface ZIKQueryResponse : NSObject
+
+@property (nonatomic, retain, readonly) NSArray *links;
+@property (nonatomic, retain) NSArray *devices;
+@property (nonatomic, retain, readonly) NSString *server;
+@property (nonatomic, retain,readonly) NSString *ql;
+
+-(instancetype) initWithDictionary:(NSDictionary *) data;
++(instancetype) initWithDictionary:(NSDictionary *) data;
+
+-(ZIKStream *) resultsStream;
+
+@end

--- a/Pod/Classes/ZIKQueryResponse.m
+++ b/Pod/Classes/ZIKQueryResponse.m
@@ -1,0 +1,70 @@
+//
+//  ZIKQueryResponse.m
+//  Pods
+//
+//  Created by Matthew Dobson on 2/17/16.
+//
+//
+
+#import "ZIKQueryResponse.h"
+#import "ZIKStream.h"
+#import "ZIKLink.h"
+#import "ZIKDevice.h"
+
+@interface ZIKQueryResponse()
+
+@property (nonatomic, retain, readwrite) NSArray *links;
+@property (nonatomic, retain, readwrite) NSString *server;
+@property (nonatomic, retain, readwrite) NSString *ql;
+
+@end
+
+@implementation ZIKQueryResponse
+
+-(instancetype) initWithDictionary:(NSDictionary *) data {
+    NSLog(@"Props: %@", data[@"properties"]);
+    if (self = [super init]) {
+        self.server = data[@"properties"][@"name"];
+        self.ql = data[@"properties"][@"ql"];
+        NSMutableArray *links = [[NSMutableArray alloc] init];
+        
+        for (NSDictionary *linkData in data[@"links"]) {
+            ZIKLink *link = [ZIKLink initWithDictionary:linkData];
+            [links addObject:link];
+        }
+        
+        self.links = [NSArray arrayWithArray:links];
+        
+        if ([data objectForKey:@"entities"] != nil) {
+            NSMutableArray *devices = [[NSMutableArray alloc] init];
+            for (NSDictionary *deviceData in data[@"entities"]) {
+                [devices addObject:[ZIKDevice initWithDictionary:deviceData]];
+            }
+            self.devices = [NSArray arrayWithArray:devices];
+        }
+    }
+    
+    return self;
+}
+
++(instancetype) initWithDictionary:(NSDictionary *) data {
+    return [[ZIKQueryResponse alloc] initWithDictionary:data];
+}
+
+-(ZIKStream *) resultsStream {
+    NSPredicate *pred = [NSPredicate predicateWithFormat:@"rel CONTAINS %@", @"http://rels.zettajs.io/query"];
+    NSArray *filteredStreams = [self.links filteredArrayUsingPredicate:pred];
+    if ([filteredStreams count] != 0) {
+        ZIKLink *entry = filteredStreams[0];
+        return [ZIKStream initWithLink:entry];
+    } else {
+        return nil;
+    }
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<ZIKQueryResponse %@ against %@>", self.ql, self.server];
+}
+
+
+@end

--- a/Pod/Classes/ZIKSession.h
+++ b/Pod/Classes/ZIKSession.h
@@ -26,6 +26,7 @@
 #import <Foundation/Foundation.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 #import "ZIKQuery.h"
+#import "ZIKQueryResponse.h"
 #import "ispdy.h"
 
 /**
@@ -35,6 +36,7 @@
 
 typedef void (^ServerCompletionBlock)(NSError *error, ZIKServer *server);
 typedef void (^DevicesCompletionBlock)(NSError *error, NSArray *devices);
+typedef void (^QueryResponseCompletionBlock)(NSError *error, ZIKQueryResponse *devices);
 
 /**
  The current endpoint the `ZIKSession` is targeting. All requests will be made against this endpoint unless specifically provided another URL.
@@ -99,11 +101,12 @@ typedef void (^DevicesCompletionBlock)(NSError *error, NSArray *devices);
 /**
  Query devices from a Zetta HTTP API.
  
- @param queries An `NSArray` of `ZIKQuery` objects containing information on the devices that should be retrieved.
+ @param queries A `ZIKQuery` object containing information on the devices that should be retrieved.
  
- @return An RACSignal object that can be subscribed to and operated on. This RACSignal will produce `ZIKDevice` objects.
+ @return An RACSignal object that can be subscribed to and operated on. This RACSignal will produce a `ZIKQueryResponse` object.
  */
-- (RACSignal *) queryDevices:(NSArray *)queries;
+- (RACSignal *) queryDevices:(ZIKQuery *)queries;
+
 
 /**
  Search for a Zetta server by name.
@@ -125,10 +128,18 @@ typedef void (^DevicesCompletionBlock)(NSError *error, NSArray *devices);
 /**
  Query devices from a Zetta HTTP API.
  
- @param queries An `NSArray` of `ZIKQuery` objects containing information on the devices that should be retrieved.
+ @param query A `ZIKQuery` object containing information on the devices that should be retrieved.
  @param block A block object that will be called when the HTTP transaction completes. This block has no return value and has two arguments: The potential error from the HTTP transaction, and an `NSArray` of `ZIKDevice` objects that fullfil the query.
  */
-- (void) queryDevices:(NSArray *)queries withCompletion:(DevicesCompletionBlock)block;
+- (void) queryDevices:(ZIKQuery *)query withCompletion:(DevicesCompletionBlock)block;
+
+/**
+ Query devices from a Zetta HTTP API.
+ 
+ @param query A `ZIKQuery` object containing information on the devices that should be retrieved.
+ @param block A block object that will be called when the HTTP transaction completes. This block has no return value and has two arguments: The potential error from the HTTP transaction, and a `ZIKQueryResponse` object that has the immediate results of the query, and a method to stream devices that fulfill the query afterward.
+ */
+- (void) queryDevices:(ZIKQuery *)query withResponseCompletion:(QueryResponseCompletionBlock)block;
 
 /**
  Start an HTTP task over the Zetta API, and receive an observable for it.

--- a/Pod/Classes/ZIKSession.m
+++ b/Pod/Classes/ZIKSession.m
@@ -131,6 +131,7 @@ typedef void (^DeviceQueryCompletion)(int count, RACSignal *devicesObservable);
 }
 
 - (RACSignal *) root:(NSURL *)url {
+    self.apiEndpoint = url;
     RACSignal *rootResponse = [self get:url];
     
     RACSignal *root = [rootResponse map:^id(NSDictionary *value) {

--- a/Pod/Classes/ZIKStream.m
+++ b/Pod/Classes/ZIKStream.m
@@ -33,6 +33,7 @@
 #import "ZIKSpdyDelegate.h"
 #import "ZIKPubSubBroker.h"
 #import "ZIKMultiplexStreamEntry.h"
+#import "ZIKDevice.h"
 #import "ispdy.h"
 
 @interface ZIKStream () <SRWebSocketDelegate>
@@ -42,6 +43,7 @@
 @property (nonatomic, retain) id<RACSubscriber> subscriber;
 @property (nonatomic) BOOL flowing;
 @property (nonatomic, retain, readwrite) NSString *title;
+@property (nonatomic, retain, readwrite) NSArray *rel;
 @property (nonatomic, retain, readwrite) RACSignal *signal;
 @property (nonatomic, readwrite) BOOL multiplexed;
 
@@ -93,6 +95,10 @@
                 }];
             }
         }
+        
+        if ([data objectForKey:@"rel"]) {
+            self.rel = data[@"rel"];
+        }
     }
     return self;
 }
@@ -106,6 +112,7 @@
         self.multiplexed = multiplexed;
         self.title = link.title;
         self.url = link.href;
+        self.rel = link.rel;
         self.flowing = NO;
         NSURL *streamUrl = [NSURL URLWithString:self.url];
         ZIKSession *session = [ZIKSession sharedSession];
@@ -182,6 +189,8 @@
         } else {
             if ([self.title isEqualToString:@"logs"]) {
                 [self.subscriber sendNext:[ZIKLogStreamEntry initWithDictionary:data]];
+            } else if ([self.rel containsObject:@"http://rels.zettajs.io/query"]) {
+                [self.subscriber sendNext:[ZIKDevice initWithDictionary:data]];
             } else {
                 [self.subscriber sendNext:[ZIKStreamEntry initWithDictionary:data]];
             }

--- a/ZettaKit.podspec
+++ b/ZettaKit.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/zettajs/ZettaKit.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/zettajs'
 
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '9.0'
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'


### PR DESCRIPTION
- Introduces a breaking change to the query interface. Querying methods no longer accept an NSArray of ZIKQuery objects
- Added init methods to ZIKQuery to allow for cross server queries, and queries that search for all devices.
- Added ZIKQueryResponse class that will allow you to interact with the device streaming capabilities over the API.
- Added property ZIKLogStreamEntry indicating arguments provided to a transition. #15
