### PR TITLE
Fetch updates

### DIFF
--- a/Example/Tests/ZIKDeviceTests.m
+++ b/Example/Tests/ZIKDeviceTests.m
@@ -73,7 +73,7 @@ describe(@"ZIKDevice", ^{
     describe(@"streams", ^{
         it(@"Will return all streams that can be subscribed to.", ^{
             ZIKDevice *device = [ZIKDevice initWithDictionary:actuator];
-            NSArray *streams = [device streams];
+            NSArray *streams = [device getAllStreams];
             expect([streams count]).to.equal(2);
         });
     });

--- a/Example/Tests/ZIKLogStreamEntryTests.m
+++ b/Example/Tests/ZIKLogStreamEntryTests.m
@@ -1,0 +1,44 @@
+//
+//  ZIKLogStreamEntryTests.m
+//  ZettaKit
+//
+//  Created by Matthew Dobson on 2/25/16.
+//  Copyright © 2016 Matthew Dobson. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ZIKLogStreamEntry.h"
+#import "ZIKTransition.h"
+
+SpecBegin(ZIKLogStreamEntry)
+
+NSDictionary *data = @{@"topic":@"input/205c8651-2793-4e97-94a9-ce0eb61e2cb3/logs",@"timestamp":@1456430816996,@"transition":@"input",@"input":@[@{@"name":@"t1",@"value":@"1"},@{@"name":@"t2",@"value":@"2"}],@"properties":@{@"id":@"205c8651-2793-4e97-94a9-ce0eb61e2cb3",@"type":@"input",@"state":@"on"},@"actions":@[@{@"class":@[@"transition"],@"name":@"input",@"method":@"POST",@"href":@"http://localhost:1338/servers/cloud/devices/205c8651-2793-4e97-94a9-ce0eb61e2cb3",@"fields":@[@{@"type":@"text",@"name":@"t1"},@{@"type":@"text",@"name":@"t2"},@{@"name":@"action",@"type":@"hidden",@"value":@"input"}]}]};
+
+NSDictionary *data2 = @{@"topic":@"input/205c8651-2793-4e97-94a9-ce0eb61e2cb3/logs",@"timestamp":@1456430816996,@"transition":@"input",@"input":@[@{@"name":@"t1",@"value":@"1"},@{@"name":@"t2",@"value":@"2"}],@"properties":@{@"id":@"205c8651-2793-4e97-94a9-ce0eb61e2cb3",@"type":@"input",@"state":@"on"},@"actions":@[]};
+
+NSDictionary *data3 = @{@"topic":@"input/205c8651-2793-4e97-94a9-ce0eb61e2cb3/logs",@"timestamp":@1456430816996,@"transition":@"input",@"properties":@{@"id":@"205c8651-2793-4e97-94a9-ce0eb61e2cb3",@"type":@"input",@"state":@"on"}};
+
+describe(@"ZIKLogStreamEntry", ^{
+    it(@"Initializes inputs and actions properly when they are present", ^{
+        ZIKLogStreamEntry *entry = [ZIKLogStreamEntry initWithDictionary:data];
+        expect(entry.actions.count).to.equal(1);
+        expect(entry.input.count).to.equal(2);
+        ZIKTransition *transition = entry.actions[0];
+        expect(transition.name).to.equal(@"input");
+    });
+    
+    it(@"Initializes inputs and actions properly when actions are empty", ^{
+        ZIKLogStreamEntry *entry = [ZIKLogStreamEntry initWithDictionary:data2];
+        expect(entry.actions.count).to.equal(0);
+        expect(entry.input.count).to.equal(2);
+    });
+    
+    it(@"Initializes inputs and actions properly when actions and input are not present", ^{
+        ZIKLogStreamEntry *entry = [ZIKLogStreamEntry initWithDictionary:data3];
+        expect(entry.actions.count).to.equal(0);
+        expect(entry.input.count).to.equal(0);
+    });
+    
+});
+
+SpecEnd

--- a/Example/ZettaKit.xcodeproj/project.pbxproj
+++ b/Example/ZettaKit.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		F5234B3C1ADD9D2B002CEC4F /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5234B371ADD9D2B002CEC4F /* ViewController.m */; };
 		F5234B3D1ADD9D2B002CEC4F /* SingleDeviceViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5234B391ADD9D2B002CEC4F /* SingleDeviceViewController.m */; };
 		F5234B3E1ADD9D2B002CEC4F /* DeviceTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5234B3B1ADD9D2B002CEC4F /* DeviceTableViewController.m */; };
+		F53E8E4B1C7F9CEE00E2ED12 /* ZIKLogStreamEntryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F53E8E4A1C7F9CEE00E2ED12 /* ZIKLogStreamEntryTests.m */; };
 		F55650421ADEB13300EE2E2B /* ZIKDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F55650411ADEB13300EE2E2B /* ZIKDeviceTests.m */; };
 		F5B64E8B1B87860C004A556D /* EndpointViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5B64E8A1B87860C004A556D /* EndpointViewController.m */; };
 		F5D382AA1C6128A500CCEB3E /* ZIKStreamTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5D382A91C6128A500CCEB3E /* ZIKStreamTests.m */; };
@@ -90,6 +91,7 @@
 		F5234B391ADD9D2B002CEC4F /* SingleDeviceViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SingleDeviceViewController.m; sourceTree = "<group>"; };
 		F5234B3A1ADD9D2B002CEC4F /* DeviceTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceTableViewController.h; sourceTree = "<group>"; };
 		F5234B3B1ADD9D2B002CEC4F /* DeviceTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceTableViewController.m; sourceTree = "<group>"; };
+		F53E8E4A1C7F9CEE00E2ED12 /* ZIKLogStreamEntryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZIKLogStreamEntryTests.m; sourceTree = "<group>"; };
 		F55650411ADEB13300EE2E2B /* ZIKDeviceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZIKDeviceTests.m; sourceTree = "<group>"; };
 		F5925CE71B2B22C900F71766 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		F5B64E891B87860C004A556D /* EndpointViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EndpointViewController.h; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 		6003F5B5195388D20070C39A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F53E8E4A1C7F9CEE00E2ED12 /* ZIKLogStreamEntryTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 				F55650411ADEB13300EE2E2B /* ZIKDeviceTests.m */,
 				F51C9A131AE01EAB004BC6FA /* ZIKLinkTests.m */,
@@ -457,6 +460,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F5D382AA1C6128A500CCEB3E /* ZIKStreamTests.m in Sources */,
+				F53E8E4B1C7F9CEE00E2ED12 /* ZIKLogStreamEntryTests.m in Sources */,
 				F5E041821C7CFBA500411377 /* ZIKQueryTests.m in Sources */,
 				F51C9A281AE0270E004BC6FA /* ZIKUtilTests.m in Sources */,
 				F51C9A141AE01EAB004BC6FA /* ZIKLinkTests.m in Sources */,

--- a/Example/ZettaKit/Base.lproj/Main_iPhone.storyboard
+++ b/Example/ZettaKit/Base.lproj/Main_iPhone.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="f5o-Yo-kqz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="f5o-Yo-kqz">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/Example/ZettaKit/DeviceTableViewController.h
+++ b/Example/ZettaKit/DeviceTableViewController.h
@@ -26,9 +26,11 @@
 
 #import <UIKit/UIKit.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
+#import "ZIKServer.h"
 
 @interface DeviceTableViewController : UITableViewController
 
 @property (nonatomic, retain) RACSignal *serverSignal;
+@property (nonatomic, retain) ZIKServer *server;
 
 @end

--- a/Example/ZettaKit/ViewController.m
+++ b/Example/ZettaKit/ViewController.m
@@ -70,20 +70,20 @@
     }];
     
 
-    [root subscribeNext:^(ZIKRoot *x) {
-        _stream = [x multiplexWebsocketStream];
-        [_stream resume];
-        NSLog(@"%@", _stream);
-        [_stream.signal subscribeNext:^(ZIKMultiplexStreamEntry *x) {
-            NSLog(@"%@", x);
-        }];
-        while (1) {
-            if ([_stream isOpen]) {
-                [_stream subscribe:@"*"];
-                break;
-            }
-        }
-    }];
+//    [root subscribeNext:^(ZIKRoot *x) {
+//        _stream = [x multiplexWebsocketStream];
+//        [_stream resume];
+//        NSLog(@"%@", _stream);
+//        [_stream.signal subscribeNext:^(ZIKMultiplexStreamEntry *x) {
+//            NSLog(@"%@", x);
+//        }];
+//        while (1) {
+//            if ([_stream isOpen]) {
+//                [_stream subscribe:@"*"];
+//                break;
+//            }
+//        }
+//    }];
     
 }
 

--- a/Example/ZettaKit/ZIKDeviceViewController.m
+++ b/Example/ZettaKit/ZIKDeviceViewController.m
@@ -122,6 +122,7 @@
             vc.transition = nil;
             NSArray *keys = [self.device.properties allKeys];
             vc.stream = [self.device stream:keys[path.row]];
+
         }
         // Pass any objects to the view controller here, like...
     }

--- a/Example/ZettaKit/ZIKTransitionViewController.m
+++ b/Example/ZettaKit/ZIKTransitionViewController.m
@@ -129,6 +129,7 @@
         
         [self.device transition:self.transition.name withArguments:dict andCompletion:^(NSError *err, ZIKDevice *device) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                NSLog(@"Error: %@", err);
                 self.device = device;
                 [self transitionBack];
                 
@@ -137,6 +138,7 @@
     } else {
         [self.device transition:self.transition.name andCompletion:^(NSError *err, ZIKDevice *device) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                NSLog(@"Error: %@", err);
                 self.device = device;
                 [self transitionBack];
             });

--- a/Pod/Classes/ZIKDevice.h
+++ b/Pod/Classes/ZIKDevice.h
@@ -153,6 +153,10 @@ typedef void (^CompletionBlock)(NSError * _Nullable err, ZIKDevice * _Nullable d
  
  @return An NSArray of ZIKStream instances that correspond to every stream on the device representation.
  */
-- (NSArray * _Nonnull)streams;
+- (NSArray * _Nonnull)getAllStreams;
+
+-(RACSignal * _Nonnull)fetch;
+
+-(void)fetchWithCompletion:(CompletionBlock _Nonnull)block;
 
 @end

--- a/Pod/Classes/ZIKDevice.h
+++ b/Pod/Classes/ZIKDevice.h
@@ -155,8 +155,18 @@ typedef void (^CompletionBlock)(NSError * _Nullable err, ZIKDevice * _Nullable d
  */
 - (NSArray * _Nonnull)getAllStreams;
 
+/**
+ Fetch the current representation of the `ZIKDevice`.
+ 
+ @return An RACSignal object that can be subscribed to and operated on using ReactiveCocoa extensions.
+ */
 -(RACSignal * _Nonnull)fetch;
 
+/**
+ Fetch the current representation of the `ZIKDevice`.
+ 
+ @param block A block object that will be called when the HTTP transaction completes. This block has no return value and has two arguments: The potential error from the HTTP transaction, and the `ZIKDevice` object representing the server.
+ */
 -(void)fetchWithCompletion:(CompletionBlock _Nonnull)block;
 
 @end

--- a/Pod/Classes/ZIKDevice.m
+++ b/Pod/Classes/ZIKDevice.m
@@ -193,15 +193,15 @@
     NSArray *filteredLinks = [self.links filteredArrayUsingPredicate:pred];
     ZIKLink *selfLink = filteredLinks[0];
     NSURLRequest *req = [NSURLRequest requestWithURL:[NSURL URLWithString:selfLink.href]];
-    return [[ZIKSession sharedSession] taskForRequest:req];
+    RACSignal *fetchSignal = [[ZIKSession sharedSession] taskForRequest:req];
+    return [fetchSignal map:^id(NSDictionary *value) {
+        return [ZIKDevice initWithDictionary:value];
+    }];
 }
 
 -(void)fetchWithCompletion:(CompletionBlock _Nonnull)block {
     RACSignal *fetchSignal = [self fetch];
-    RACSignal *deviceMap = [fetchSignal map:^id(NSDictionary *value) {
-        return [ZIKDevice initWithDictionary:value];
-    }];
-    RACSignal *singleDevice = [deviceMap take:1];
+    RACSignal *singleDevice = [fetchSignal take:1];
     
     [singleDevice subscribeNext:^(id x) {
         block(nil, x);

--- a/Pod/Classes/ZIKLogStreamEntry.h
+++ b/Pod/Classes/ZIKLogStreamEntry.h
@@ -53,7 +53,12 @@
 /**
  The inputs to the transition.
  */
-@property (nonatomic, retain, readonly) NSDictionary *inputs;
+@property (nonatomic, retain, readonly) NSDictionary *input;
+
+/**
+ The new available actions for the device.
+ */
+@property (nonatomic, retain, readonly) NSArray *actions;
 
 ///---------------------------
 /// @name Initialization

--- a/Pod/Classes/ZIKLogStreamEntry.m
+++ b/Pod/Classes/ZIKLogStreamEntry.m
@@ -25,6 +25,7 @@
 
 
 #import "ZIKLogStreamEntry.h"
+#import "ZIKTransition.h"
 
 @interface ZIKLogStreamEntry ()
 
@@ -32,7 +33,8 @@
 @property (nonatomic, retain, readwrite) NSNumber *timestamp;
 @property (nonatomic, retain, readwrite) NSString *transition;
 @property (nonatomic, retain, readwrite) NSString *deviceState;
-@property (nonatomic, retain, readwrite) NSDictionary *inputs;
+@property (nonatomic, retain, readwrite) NSDictionary *input;
+@property (nonatomic, retain, readwrite) NSArray *actions;
 
 @end
 
@@ -46,10 +48,21 @@
         self.deviceState = properties[@"state"];
         self.transition = data[@"transition"];
         
-        if(data[@"inputs"]) {
-            self.inputs = data[@"inputs"];
+        if(![[data objectForKey:@"input"] isEqual:[NSNull null]]) {
+            self.input = data[@"input"];
         } else {
-            self.inputs = @{};
+            self.input = @{};
+        }
+        
+        if (![[data objectForKey:@"actions"] isEqual:[NSNull null]]) {
+            NSMutableArray *transitions = [[NSMutableArray alloc] init];
+            for (NSDictionary *actionData in data[@"actions"]) {
+                ZIKTransition *trans = [ZIKTransition initWithDictionary:actionData];
+                [transitions addObject:trans];
+            }
+            self.actions = [NSArray arrayWithArray:transitions];
+        } else {
+            self.actions = @[];
         }
     }
     return self;

--- a/Pod/Classes/ZIKServer.h
+++ b/Pod/Classes/ZIKServer.h
@@ -62,7 +62,7 @@ typedef void (^ServerCompletionBlock)(NSError * _Nullable err, ZIKServer * _Null
  
  @return The newly-initialized `ZIKServer` object.
  */
-+ (instancetype) initWithDictionary:(NSDictionary *)data;
++ (instancetype _Nonnull) initWithDictionary:(NSDictionary *)data;
 
 /**
  Initializes a `ZIKServer` with the specified siren document in `NSDictionary` form.
@@ -71,10 +71,20 @@ typedef void (^ServerCompletionBlock)(NSError * _Nullable err, ZIKServer * _Null
  
  @return The newly-initialized `ZIKServer` object.
  */
-- (instancetype) initWithDictionary:(NSDictionary *)data;
+- (instancetype _Nonnull) initWithDictionary:(NSDictionary *)data;
 
+/**
+ Fetch the current representation of the `ZIKServer`.
+ 
+ @return An RACSignal object that can be subscribed to and operated on using ReactiveCocoa extensions.
+ */
 - (RACSignal * _Nonnull) fetch;
 
+/**
+ Fetch the current representation of the `ZIKServer`.
+ 
+ @param block A block object that will be called when the HTTP transaction completes. This block has no return value and has two arguments: The potential error from the HTTP transaction, and the `ZIKServer` object representing the server.
+ */
 - (void) fetchWithCompletion:(ServerCompletionBlock)block;
 
 @end

--- a/Pod/Classes/ZIKServer.h
+++ b/Pod/Classes/ZIKServer.h
@@ -24,12 +24,15 @@
 //  THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <ReactiveCocoa/ReactiveCocoa.h>
+
 
 /**
  The `ZIKServer` class abstracts away the Zetta server resource.
  */
 
 @interface ZIKServer : NSObject
+typedef void (^ServerCompletionBlock)(NSError * _Nullable err, ZIKServer * _Nullable device);
 
 /**
  The devices that currently belong to the server. An `NSArray` of `ZIKDevice` objects.
@@ -69,5 +72,9 @@
  @return The newly-initialized `ZIKServer` object.
  */
 - (instancetype) initWithDictionary:(NSDictionary *)data;
+
+- (RACSignal * _Nonnull) fetch;
+
+- (void) fetchWithCompletion:(ServerCompletionBlock)block;
 
 @end

--- a/Pod/Classes/ZIKServer.m
+++ b/Pod/Classes/ZIKServer.m
@@ -61,16 +61,16 @@
     NSArray *filteredLinks = [self.links filteredArrayUsingPredicate:pred];
     ZIKLink *selfLink = filteredLinks[0];
     NSURLRequest *req = [NSURLRequest requestWithURL:[NSURL URLWithString:selfLink.href]];
-    return [[ZIKSession sharedSession] taskForRequest:req];
+    RACSignal *fetchSignal = [[ZIKSession sharedSession] taskForRequest:req];
+    return [fetchSignal map:^id(NSDictionary *value) {
+        return [ZIKServer initWithDictionary:value];
+    }];
 }
 
 - (void) fetchWithCompletion:(ServerCompletionBlock)block {
     RACSignal *fetchSignal = [self fetch];
-    RACSignal *serverMap = [fetchSignal map:^id(NSDictionary *value) {
-        return [ZIKServer initWithDictionary:value];
-    }];
     
-    RACSignal *singleServer = [serverMap take:1];
+    RACSignal *singleServer = [fetchSignal take:1];
     
     [singleServer subscribeNext:^(id x) {
         block(nil, x);

--- a/Pod/Classes/ZIKServer.m
+++ b/Pod/Classes/ZIKServer.m
@@ -9,6 +9,7 @@
 #import "ZIKServer.h"
 #import "ZIKLink.h"
 #import "ZIKDevice.h"
+#import "ZIKSession.h"
 
 @interface ZIKServer ()
 
@@ -53,6 +54,29 @@
 
 - (NSString *)description {
     return [NSString stringWithFormat:@"<ZIKServer: %@>", self.name];
+}
+
+- (RACSignal *) fetch {
+    NSPredicate *pred = [NSPredicate predicateWithFormat:@"rel CONTIANS %@", @"self"];
+    NSArray *filteredLinks = [self.links filteredArrayUsingPredicate:pred];
+    ZIKLink *selfLink = filteredLinks[0];
+    NSURLRequest *req = [NSURLRequest requestWithURL:[NSURL URLWithString:selfLink.href]];
+    return [[ZIKSession sharedSession] taskForRequest:req];
+}
+
+- (void) fetchWithCompletion:(ServerCompletionBlock)block {
+    RACSignal *fetchSignal = [self fetch];
+    RACSignal *serverMap = [fetchSignal map:^id(NSDictionary *value) {
+        return [ZIKServer initWithDictionary:value];
+    }];
+    
+    RACSignal *singleServer = [serverMap take:1];
+    
+    [singleServer subscribeNext:^(id x) {
+        block(nil, x);
+    } error:^(NSError *error) {
+        block(error, nil);
+    }];
 }
 
 @end

--- a/Pod/Classes/ZIKStream.h
+++ b/Pod/Classes/ZIKStream.h
@@ -161,4 +161,5 @@
 - (void) unsubscribe:(NSString *)topic;
 
 
+
 @end

--- a/Pod/Classes/ZIKStream.m
+++ b/Pod/Classes/ZIKStream.m
@@ -75,6 +75,7 @@
         }
         
         if ([data objectForKey:@"href"]) {
+            //self.href = data[@"href"];
             self.url = data[@"href"];
             self.flowing = NO;
             NSURL *streamUrl = [NSURL URLWithString:self.url];

--- a/ZettaKit.podspec
+++ b/ZettaKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ZettaKit"
-  s.version          = "0.0.5"
+  s.version          = "0.0.6"
   s.summary          = "A Reactive Hypermedia Client for the Zetta HTTP API."
   s.description      = <<-DESC
                         This library allows you to harness the power of Reactive Programming to interact with the Zetta HTTP API.


### PR DESCRIPTION
- Adds fetch functionality to the `ZIKServer` class. RACSignal and block based methods are supported.
- Adds fetch functionality to the `ZIKDevice` class. RACSignal and block based methods are supported.
- Adds actions to `ZIKLogStream` events when applicable
- Fixes an issue where inputs weren't populating in `ZIKLogStream` events.
