### PR TITLE
Updated type for inputs from dictionary to array of dictionaries.

### DIFF
--- a/Pod/Classes/ZIKLogStreamEntry.h
+++ b/Pod/Classes/ZIKLogStreamEntry.h
@@ -53,7 +53,7 @@
 /**
  The inputs to the transition.
  */
-@property (nonatomic, retain, readonly) NSDictionary *input;
+@property (nonatomic, retain, readonly) NSArray *inputs;
 
 /**
  The new available actions for the device.

--- a/Pod/Classes/ZIKLogStreamEntry.m
+++ b/Pod/Classes/ZIKLogStreamEntry.m
@@ -33,7 +33,7 @@
 @property (nonatomic, retain, readwrite) NSNumber *timestamp;
 @property (nonatomic, retain, readwrite) NSString *transition;
 @property (nonatomic, retain, readwrite) NSString *deviceState;
-@property (nonatomic, retain, readwrite) NSDictionary *input;
+@property (nonatomic, retain, readwrite) NSArray *inputs;
 @property (nonatomic, retain, readwrite) NSArray *actions;
 
 @end
@@ -49,9 +49,9 @@
         self.transition = data[@"transition"];
         
         if(![[data objectForKey:@"input"] isEqual:[NSNull null]]) {
-            self.input = data[@"input"];
+            self.inputs = data[@"input"];
         } else {
-            self.input = @{};
+            self.inputs = @[];
         }
         
         if (![[data objectForKey:@"actions"] isEqual:[NSNull null]]) {


### PR DESCRIPTION
I was getting a crash accessing .`input` since it was typed as an `NSDictionary` but was in fact an `NSArray`.

 Also updated property name from `input` to `inputs`.
